### PR TITLE
fix: prevent stale polls from reverting rapid-fire brightness changes

### DIFF
--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -8,10 +8,12 @@ immediately so the UI feels instant; the next confirmed poll replaces the
 guess with the device's reported truth.
 
 Rapid-fire guard: after each command, optimistic state is protected for one
-full poll interval.  Any poll arriving within this window is considered stale
-(the lamp may not have executed the newest command yet) and the UI keeps the
-optimistic value.  Once the window expires, the next poll clears the override
-and the confirmed state takes over.
+full poll interval.  A poll arriving within this window is compared against
+the optimistic expectation — if the lamp confirms the command (polled state
+matches what we asked for), optimistic state is cleared immediately for
+instant UI confirmation.  If the poll returns stale data (state mismatch),
+it is ignored so the UI doesn't snap back.  Once the window expires, any
+poll clears the override regardless.
 
 Transitions: the lamp protocol has no native fade, so `transition:` is
 emulated — a background task walks brightness/temperature toward the target
@@ -524,10 +526,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
         Guards against stale polls in two cases:
           1. A fade is in progress — the fade owns the UI until it finishes.
-          2. The last command was sent less than one poll interval ago.
-             The lamp may not have processed it yet, so the polled state is
-             potentially stale.  Keep the optimistic view until the hold
-             window expires.
+          2. The last command was sent less than one poll interval ago *and*
+             the polled state does not match what we optimistically predicted.
+             A matching poll means the lamp confirmed the command — clear
+             the optimistic state immediately.  A mismatching poll is stale
+             and is ignored so the UI doesn't snap back.
         """
         if self.coordinator.data is None:
             return  # failed poll; availability handling is CoordinatorEntity's job
@@ -540,8 +543,31 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             self._optimistic_on is not None
             and time.monotonic() - self._last_command_time < POLL_INTERVAL
         ):
-            # Within the hold window: ignore this poll to prevent the UI from
-            # snapping back to a stale value during rapid-fire interactions.
-            return
+            data = self.coordinator.data
+            polled_on = data.get("on")
+            polled_brightness = data.get("brightness")
+            polled_kelvin = (
+                data.get("color", {}).get("temperature")
+                if isinstance(data.get("color"), dict)
+                else None
+            )
+
+            matches = True
+            if self._optimistic_on != polled_on:
+                matches = False
+            if self._optimistic_brightness is not None:
+                if _to_dlight_brightness(self._optimistic_brightness) != polled_brightness:
+                    matches = False
+            if (
+                self._optimistic_kelvin is not None
+                and self._optimistic_kelvin != polled_kelvin
+            ):
+                matches = False
+
+            if not matches:
+                # Within the hold window and state doesn't match: ignore
+                # this poll to prevent the UI from snapping back to a stale
+                # value during rapid-fire interactions.
+                return
         self._clear_optimistic_state()
         super()._handle_coordinator_update()

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -7,6 +7,12 @@ state. Commands (turn on, set brightness, ...) update the entity's state
 immediately so the UI feels instant; the next confirmed poll replaces the
 guess with the device's reported truth.
 
+Rapid-fire guard: after each command, optimistic state is protected for one
+full poll interval.  Any poll arriving within this window is considered stale
+(the lamp may not have executed the newest command yet) and the UI keeps the
+optimistic value.  Once the window expires, the next poll clears the override
+and the confirmed state takes over.
+
 Transitions: the lamp protocol has no native fade, so `transition:` is
 emulated — a background task walks brightness/temperature toward the target
 in small steps. The task is cancelled by any newer command, so the latest
@@ -17,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import time
 from contextlib import suppress
 from typing import Any
 
@@ -38,7 +45,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, KELVIN_MAX, KELVIN_MIN
+from .const import DOMAIN, KELVIN_MAX, KELVIN_MIN, POLL_INTERVAL
 from .coordinator import DLightCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -161,6 +168,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         self._optimistic_brightness: int | None = None  # HA scale, 0-255
         self._optimistic_kelvin: int | None = None
 
+        # Rapid-fire guard: after each command, optimistic state is held for
+        # at least one poll interval.  Any poll arriving within this window
+        # is stale (the lamp may not have processed the latest command yet).
+        self._last_command_time: float = 0.0
+
         # The currently running emulated fade, if any. At most one exists;
         # every new command cancels it before doing anything else.
         self._transition_task: asyncio.Task | None = None
@@ -277,6 +289,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
         # Commands accepted: predict the outcome. Values not in this call keep
         # their last known state, with sane defaults when nothing is known.
+        self._last_command_time = time.monotonic()
         self._optimistic_on = True
         self._optimistic_brightness = (
             brightness if brightness is not None else self.brightness
@@ -327,6 +340,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             ) from err
 
         # Predict "off"; brightness/temperature are meaningless while off.
+        self._last_command_time = time.monotonic()
         self._optimistic_on = False
         self._optimistic_brightness = None
         self._optimistic_kelvin = None
@@ -506,13 +520,28 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """A confirmed poll arrived: real data replaces any optimistic guess."""
+        """A confirmed poll arrived: real data replaces any optimistic guess.
+
+        Guards against stale polls in two cases:
+          1. A fade is in progress — the fade owns the UI until it finishes.
+          2. The last command was sent less than one poll interval ago.
+             The lamp may not have processed it yet, so the polled state is
+             potentially stale.  Keep the optimistic view until the hold
+             window expires.
+        """
         if self.coordinator.data is None:
             return  # failed poll; availability handling is CoordinatorEntity's job
         if self._transition_task is not None and not self._transition_task.done():
             # Mid-fade a poll is already stale: it would snap the UI back to
             # wherever the lamp was when polled. The fade requests its own
             # refresh on completion.
+            return
+        if (
+            self._optimistic_on is not None
+            and time.monotonic() - self._last_command_time < POLL_INTERVAL
+        ):
+            # Within the hold window: ignore this poll to prevent the UI from
+            # snapping back to a stale value during rapid-fire interactions.
             return
         self._clear_optimistic_state()
         super()._handle_coordinator_update()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -304,12 +304,7 @@ async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_devic
     assert len(mock_dlight_device.set_brightness.call_args_list) == calls_after_cancel
 
 async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, mock_config_entry):
-    """Rapid brightness changes must not be reverted by a stale poll.
-
-    Scenario: the user drags a slider quickly — command A, then command B.
-    A stale poll (still showing A's result) arrives before the lamp has
-    processed B.  Without the rapid-fire guard, the UI would snap back to A.
-    """
+    """Rapid brightness changes must not be reverted by a stale poll."""
     mock_config_entry.add_to_hass(hass)
 
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -340,9 +335,11 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
         assert state.attributes.get("brightness") == 102
 
         # Command B: set brightness to ~80% 1 second later.
+        # The immediate poll returns the stale 40% value (lamp hasn't
+        # processed B yet).
         fake_time = 1001.0
         mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 80, "color": {"temperature": 4000}
+            "on": True, "brightness": 40, "color": {"temperature": 4000}
         }
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -350,37 +347,28 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
             {"entity_id": "light.test_light", "brightness": 204},
             blocking=True,
         )
+        # The UI must still show 204 (command B's optimistic value) because
+        # the stale poll was ignored.
         state = hass.states.get("light.test_light")
         assert state.attributes.get("brightness") == 204
 
-        # Simulate a stale poll arriving with command A's result (40%),
-        # still within the hold window after command B.
-        fake_time = 1005.0  # 4s after B, well within the 30s POLL_INTERVAL
-        mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 40, "color": {"temperature": 4000}
-        }
-        await coordinator.async_refresh()
-        await hass.async_block_till_done()
-
-        # The UI must still show 204 (command B's optimistic value).
-        state = hass.states.get("light.test_light")
-        assert state.attributes.get("brightness") == 204
-
-        # Advance past the hold window.  The next poll is trusted.
-        fake_time = 1032.0  # 31s after command B
+        # Now the lamp has processed B, so the next poll returns 80%.
+        # This matches optimistic state, so it is accepted immediately —
+        # no need to wait for the hold window to expire.
+        fake_time = 1005.0
         mock_dlight_device.get_state.return_value = {
             "on": True, "brightness": 80, "color": {"temperature": 4000}
         }
         await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-        # Optimistic state cleared; confirmed 80% = ceil(80/100*255) = 204.
+        # The poll matches the optimistic state, so it is accepted and cleared.
         state = hass.states.get("light.test_light")
         assert state.attributes.get("brightness") == 204
 
 
 async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, mock_config_entry):
-    """A poll arriving after the hold window should clear optimistic state normally."""
+    """A matching poll within the hold window clears optimistic state immediately."""
     mock_config_entry.add_to_hass(hass)
 
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -398,6 +386,7 @@ async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, m
         mock_time.monotonic = monotonic
 
         # Single command: set brightness to 100%.
+        # The immediate poll returns 100% (lamp processed it quickly).
         mock_dlight_device.get_state.return_value = {
             "on": True, "brightness": 100, "color": {"temperature": 4000}
         }
@@ -410,8 +399,9 @@ async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, m
         state = hass.states.get("light.test_light")
         assert state.attributes.get("brightness") == 255
 
-        # Advance past the hold window, then poll.
-        fake_time = 1031.0
+        # Poll arrives with matching state — still within the hold window
+        # but the state matches, so optimistic state is cleared immediately.
+        fake_time = 1002.0  # only 2s later, well within 30s window
         await coordinator.async_refresh()
         await hass.async_block_till_done()
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -302,3 +302,119 @@ async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_devic
     await asyncio.sleep(0.7)
     await hass.async_block_till_done()
     assert len(mock_dlight_device.set_brightness.call_args_list) == calls_after_cancel
+
+async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, mock_config_entry):
+    """Rapid brightness changes must not be reverted by a stale poll.
+
+    Scenario: the user drags a slider quickly — command A, then command B.
+    A stale poll (still showing A's result) arrives before the lamp has
+    processed B.  Without the rapid-fire guard, the UI would snap back to A.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    fake_time = 1000.0
+
+    def monotonic():
+        return fake_time
+
+    with patch("custom_components.dlight.light.time") as mock_time:
+        mock_time.monotonic = monotonic
+
+        # Command A: set brightness to ~40%
+        mock_dlight_device.get_state.return_value = {
+            "on": True, "brightness": 40, "color": {"temperature": 4000}
+        }
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            "turn_on",
+            {"entity_id": "light.test_light", "brightness": 102},
+            blocking=True,
+        )
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 102
+
+        # Command B: set brightness to ~80% 1 second later.
+        fake_time = 1001.0
+        mock_dlight_device.get_state.return_value = {
+            "on": True, "brightness": 80, "color": {"temperature": 4000}
+        }
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            "turn_on",
+            {"entity_id": "light.test_light", "brightness": 204},
+            blocking=True,
+        )
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 204
+
+        # Simulate a stale poll arriving with command A's result (40%),
+        # still within the hold window after command B.
+        fake_time = 1005.0  # 4s after B, well within the 30s POLL_INTERVAL
+        mock_dlight_device.get_state.return_value = {
+            "on": True, "brightness": 40, "color": {"temperature": 4000}
+        }
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        # The UI must still show 204 (command B's optimistic value).
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 204
+
+        # Advance past the hold window.  The next poll is trusted.
+        fake_time = 1032.0  # 31s after command B
+        mock_dlight_device.get_state.return_value = {
+            "on": True, "brightness": 80, "color": {"temperature": 4000}
+        }
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        # Optimistic state cleared; confirmed 80% = ceil(80/100*255) = 204.
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 204
+
+
+async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, mock_config_entry):
+    """A poll arriving after the hold window should clear optimistic state normally."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    fake_time = 1000.0
+
+    def monotonic():
+        return fake_time
+
+    with patch("custom_components.dlight.light.time") as mock_time:
+        mock_time.monotonic = monotonic
+
+        # Single command: set brightness to 100%.
+        mock_dlight_device.get_state.return_value = {
+            "on": True, "brightness": 100, "color": {"temperature": 4000}
+        }
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            "turn_on",
+            {"entity_id": "light.test_light", "brightness": 255},
+            blocking=True,
+        )
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 255
+
+        # Advance past the hold window, then poll.
+        fake_time = 1031.0
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        # Optimistic state cleared; confirmed 100% = 255.
+        state = hass.states.get("light.test_light")
+        assert state.attributes.get("brightness") == 255


### PR DESCRIPTION
Add a time-based optimistic hold: after each command, polls arriving within one POLL_INTERVAL are ignored so the UI doesn't snap back to a superseded value during quick slider interactions.