### PR TITLE
feat(coordinator): use lightweight ping diagnostics for health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Prevent UI inconsistencies during toggling by properly setting or clearing optimistic brightness and color temperature values in `async_toggle`.
+- Defensively handle potential exceptions from lightweight ping checks in setup and rediscovery.
 
 ## [1.6.6] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Optimize toggling via native `DLightDevice.toggle()` convenience method.
+- Use lightweight `DLightDevice.ping()` connectivity check for faster setup verification and cheap rediscovery pre-checks.
 
 ### Fixed
 - Prevent UI inconsistencies during toggling by properly setting or clearing optimistic brightness and color temperature values in `async_toggle`.

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -73,7 +73,12 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Failure is tolerated: the info payload is cosmetic (device registry
         card), and a lamp that can't answer get_info may still control fine.
         """
-        if not await self.device.ping(timeout=2.0):
+        try:
+            ping_ok = await self.device.ping(timeout=2.0)
+        except Exception:  # noqa: BLE001 — defensively catch any errors in ping
+            ping_ok = False
+
+        if not ping_ok:
             _LOGGER.warning(
                 "Device %s is offline during setup ping check (will show generic card)",
                 self.device.id,
@@ -163,7 +168,12 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.device.id,
             self._consecutive_failures,
         )
-        if await self.device.ping(timeout=2.0):
+        try:
+            ping_ok = await self.device.ping(timeout=2.0)
+        except Exception:  # noqa: BLE001 — defensively catch any errors in ping
+            ping_ok = False
+
+        if ping_ok:
             _LOGGER.debug(
                 "dLight %s is reachable on current IP %s via ping; skipping UDP sweep",
                 self.device.id,

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -73,6 +73,13 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Failure is tolerated: the info payload is cosmetic (device registry
         card), and a lamp that can't answer get_info may still control fine.
         """
+        if not await self.device.ping(timeout=2.0):
+            _LOGGER.warning(
+                "Device %s is offline during setup ping check (will show generic card)",
+                self.device.id,
+            )
+            return
+
         try:
             async with asyncio.timeout(POLL_TIMEOUT):
                 info = await self.device.get_info()
@@ -156,6 +163,14 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.device.id,
             self._consecutive_failures,
         )
+        if await self.device.ping(timeout=2.0):
+            _LOGGER.debug(
+                "dLight %s is reachable on current IP %s via ping; skipping UDP sweep",
+                self.device.id,
+                self.device.ip,
+            )
+            return
+
         try:
             devices = await discover_devices(discovery_duration=REDISCOVERY_DURATION)
         except Exception:  # noqa: BLE001 — best-effort recovery, never raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def mock_dlight_device():
         mock_device.turn_on = AsyncMock()
         mock_device.turn_off = AsyncMock()
         mock_device.toggle = AsyncMock()
+        mock_device.ping = AsyncMock(return_value=True)
         mock_device.set_brightness = AsyncMock()
         mock_device.set_color_temperature = AsyncMock()
         mock_device.flash = AsyncMock(return_value=True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ async def test_rediscovery_heals_ip_after_consecutive_failures(
     coordinator = mock_config_entry.runtime_data
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    mock_dlight_device.ping.return_value = False
     sweep = AsyncMock(
         return_value=[{"deviceId": "test_device_id", "ip_address": "10.0.0.99"}]
     )
@@ -40,6 +41,7 @@ async def test_rediscovery_same_ip_leaves_entry_alone(
     coordinator = mock_config_entry.runtime_data
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    mock_dlight_device.ping.return_value = False
     sweep = AsyncMock(
         return_value=[{"deviceId": "test_device_id", "ip_address": "127.0.0.1"}]
     )
@@ -71,3 +73,39 @@ async def test_successful_poll_resets_failure_counter(
         await hass.async_block_till_done()
 
     sweep.assert_not_called()
+
+
+async def test_rediscovery_skipped_if_ping_succeeds(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """If the device fails state polling but answers ping, we skip the UDP sweep."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    mock_dlight_device.ping.return_value = True
+    sweep = AsyncMock(return_value=[])
+
+    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+        for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    sweep.assert_not_called()
+    mock_dlight_device.ping.assert_called_with(timeout=2.0)
+
+
+async def test_coordinator_setup_ping_failure(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """If ping fails during coordinator setup, we return early and skip get_info."""
+    mock_dlight_device.ping.return_value = False
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_dlight_device.ping.assert_called_with(timeout=2.0)
+    mock_dlight_device.get_info.assert_not_called()
+

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -109,3 +109,39 @@ async def test_coordinator_setup_ping_failure(
     mock_dlight_device.ping.assert_called_with(timeout=2.0)
     mock_dlight_device.get_info.assert_not_called()
 
+
+async def test_coordinator_setup_ping_exception(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """If ping raises an exception during setup, we treat it as offline, return early and skip get_info."""
+    mock_dlight_device.ping.side_effect = Exception("ping crash")
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_dlight_device.ping.assert_called_with(timeout=2.0)
+    mock_dlight_device.get_info.assert_not_called()
+
+
+async def test_rediscovery_ping_exception_triggers_sweep(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """If ping raises an exception during rediscovery, we proceed with the UDP sweep."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    mock_dlight_device.ping.side_effect = Exception("ping crash")
+    sweep = AsyncMock(return_value=[])
+
+    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+        for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    sweep.assert_awaited_once()
+    mock_dlight_device.ping.assert_called_with(timeout=2.0)
+
+


### PR DESCRIPTION
coordinator: Use lightweight ping for connection health pre-checks

Currently, verifying connectivity during setup and recovery relies on full
TCP-based queries (get_info and get_state). This adds unnecessary overhead
and TCP load to both Home Assistant and the lamp, especially when checking
offline status or attempting recovery.

Introduce lightweight DLightDevice.ping() checks introduced in dlight-client
v2.0.0. This probe uses a fast, lightweight query that returns a simple
boolean without raising exceptions, dramatically reducing load.

Utilize ping() in the following two key locations:

1. DLightCoordinator._async_setup(): Check if the device is responsive
   before requesting full get_info() payloads. If the ping probe fails,
   bail out early to avoid wasting resources on connection timeouts.

2. DLightCoordinator._async_attempt_rediscovery(): Perform a ping check at
   the last known IP address. If the device responds, skip the noisy UDP
   broadcast sweep entirely since the current IP is still valid.

Additionally, mock and assert the new behavior in the test suite:
- Update conftest.py to mock the ping() method by default.
- Add test cases in test_coordinator.py to verify that UDP sweeps are
  skipped when ping succeeds and coordinator setup exits early when
  ping fails.
- Update existing coordinator tests to mock ping failures when testing
  complete offline rediscovery.

Closes #12