### PR TITLE
feat(sync): simplify and improve state sync using state listener callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize toggling via native `DLightDevice.toggle()` convenience method.
 - Use lightweight `DLightDevice.ping()` connectivity check for faster setup verification and cheap rediscovery pre-checks.
 
+### Changed
+- Simplify state updates and transitions by synchronizing entity and coordinator states via local `dlight-client` state change listener push events rather than calling manual `async_request_refresh` poll requests.
+
 ### Fixed
 - Prevent UI inconsistencies during toggling by properly setting or clearing optimistic brightness and color temperature values in `async_toggle`.
 - Defensively handle potential exceptions from lightweight ping checks in setup and rediscovery.

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -46,6 +46,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
+    # Register the push state listener only after a successful first refresh.
+    # This avoids a memory leak / reference cycle when setup fails: if
+    # async_config_entry_first_refresh raises, the unload hooks below are never
+    # called, so we must not have registered the listener yet.
+    coordinator.device.on_state_change(coordinator._handle_device_state_change)
+    entry.async_on_unload(
+        lambda: coordinator.device.remove_state_listener(
+            coordinator._handle_device_state_change
+        )
+    )
+
     # Ensure the persistent connection is closed when the entry is unloaded.
     entry.async_on_unload(client.close)
 

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -12,10 +12,11 @@ from datetime import timedelta
 from typing import Any
 
 from dlightclient import STATUS_SUCCESS, DLightDevice, DLightError, discover_devices
+from dlightclient.models import DeviceState
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -66,6 +67,26 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # most one UDP sweep in flight at a time.
         self._consecutive_failures = 0
         self._rediscovery_task: asyncio.Task | None = None
+
+    @callback
+    def _handle_device_state_change(
+        self,
+        device: DLightDevice,
+        old_state: DeviceState,
+        new_state: DeviceState,
+    ) -> None:
+        """Handle state change notifications from the device.
+
+        DeviceState is a TypedDict, so new_state is already a plain dict at
+        runtime — no conversion is needed before handing it to the coordinator.
+        """
+        _LOGGER.debug(
+            "dLight %s state listener fired: %s -> %s",
+            device.id,
+            old_state,
+            new_state,
+        )
+        self.async_set_updated_data(new_state)
 
     async def _async_setup(self) -> None:
         """Fetch the lamp's static info once, before the first state poll.

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -261,6 +261,24 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         ):
             return
 
+        # Capture current on-state before mutating optimistic properties.
+        # Commands accepted: predict the outcome. Values not in this call keep
+        # their last known state, with sane defaults when nothing is known.
+        was_on = self.is_on
+        self._last_command_time = time.monotonic()
+        self._optimistic_on = True
+        self._optimistic_brightness = (
+            brightness if brightness is not None else self.brightness
+        )
+        if self._optimistic_brightness is None:
+            self._optimistic_brightness = 255  # unknown -> assume full
+        self._optimistic_kelvin = (
+            kelvin if kelvin is not None else self.color_temp_kelvin
+        )
+        if self._optimistic_kelvin is None:
+            self._optimistic_kelvin = KELVIN_MIN  # unknown -> assume warm
+        self.async_write_ha_state()
+
         commands = []
         if brightness is not None:
             commands.append(self.device.set_brightness(_to_dlight_brightness(brightness)))
@@ -269,7 +287,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         # Setting brightness/temperature implicitly powers the lamp on, so the
         # explicit power command is only needed for a bare turn_on call, or
         # when the lamp is (as far as we know) currently off.
-        if not commands or not self.is_on:
+        if not commands or not was_on:
             commands.insert(0, self.device.turn_on())
 
         try:
@@ -289,25 +307,6 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 },
             ) from err
 
-        # Commands accepted: predict the outcome. Values not in this call keep
-        # their last known state, with sane defaults when nothing is known.
-        self._last_command_time = time.monotonic()
-        self._optimistic_on = True
-        self._optimistic_brightness = (
-            brightness if brightness is not None else self.brightness
-        )
-        if self._optimistic_brightness is None:
-            self._optimistic_brightness = 255  # unknown -> assume full
-        self._optimistic_kelvin = (
-            kelvin if kelvin is not None else self.color_temp_kelvin
-        )
-        if self._optimistic_kelvin is None:
-            self._optimistic_kelvin = KELVIN_MIN  # unknown -> assume warm
-        self.async_write_ha_state()
-
-        # Schedule a poll to swap the guess for confirmed state.
-        await self.coordinator.async_request_refresh()
-
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off (optimistically, confirmed by the next poll).
 
@@ -325,6 +324,13 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         ):
             return
 
+        # Predict "off"; brightness/temperature are meaningless while off.
+        self._last_command_time = time.monotonic()
+        self._optimistic_on = False
+        self._optimistic_brightness = None
+        self._optimistic_kelvin = None
+        self.async_write_ha_state()
+
         try:
             async with self.coordinator.command_lock:
                 await self.device.turn_off()
@@ -341,18 +347,21 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 },
             ) from err
 
-        # Predict "off"; brightness/temperature are meaningless while off.
-        self._last_command_time = time.monotonic()
-        self._optimistic_on = False
-        self._optimistic_brightness = None
-        self._optimistic_kelvin = None
-        self.async_write_ha_state()
-
-        await self.coordinator.async_request_refresh()
-
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the light using the device's native toggle command."""
         await self._async_cancel_transition()
+        # Update optimistic state
+        self._last_command_time = time.monotonic()
+        predicted_on = not self.is_on
+        self._optimistic_on = predicted_on
+        if predicted_on:
+            self._optimistic_brightness = self.brightness or 255
+            self._optimistic_kelvin = self.color_temp_kelvin or KELVIN_MIN
+        else:
+            self._optimistic_brightness = None
+            self._optimistic_kelvin = None
+        self.async_write_ha_state()
+
         try:
             async with self.coordinator.command_lock:
                 await self.device.toggle()
@@ -368,19 +377,6 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                     "error": str(err),
                 },
             ) from err
-
-        # Update optimistic state
-        self._last_command_time = time.monotonic()
-        predicted_on = not self.is_on
-        self._optimistic_on = predicted_on
-        if predicted_on:
-            self._optimistic_brightness = self.brightness or 255
-            self._optimistic_kelvin = self.color_temp_kelvin or KELVIN_MIN
-        else:
-            self._optimistic_brightness = None
-            self._optimistic_kelvin = None
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
 
     async def _send(self, commands: list) -> None:
         """Run device commands concurrently; raise the first failure, if any.
@@ -524,11 +520,12 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             self._clear_optimistic_state()
             self.async_write_ha_state()
 
-        # Drop the task reference *before* the refresh: _handle_coordinator_update
-        # ignores polls while a fade is "active", and this fade is done — its
-        # closing refresh must be allowed through to reconcile state.
+        # Drop the task reference *before* updating state: _handle_coordinator_update
+        # ignores updates while a fade is "active", and this fade is done. Calling
+        # _handle_coordinator_update immediately reconciles the optimistic state
+        # with the latest state listener data without waiting for another poll.
         self._transition_task = None
-        await self.coordinator.async_request_refresh()
+        self._handle_coordinator_update()
 
     async def _async_cancel_transition(self) -> None:
         """Stop any in-flight fade and wait for it to fully unwind."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for the dLight test suite."""
-from unittest.mock import AsyncMock, patch
+import copy
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
@@ -21,7 +22,8 @@ def mock_dlight_device():
         mock_device = mock_device_class.return_value
         mock_device.id = "test_device_id"
         mock_device.ip = "127.0.0.1"
-        mock_device.get_state = AsyncMock(return_value={"on": True, "brightness": 50, "color": {"temperature": 4000}})
+        mock_device._current_state = {"on": True, "brightness": 50, "color": {"temperature": 4000}}
+        mock_device.get_state = AsyncMock(return_value=mock_device._current_state)
         mock_device.get_info = AsyncMock(return_value={
             "status": "SUCCESS",
             "swVersion": "1.0.0",
@@ -36,6 +38,66 @@ def mock_dlight_device():
         mock_device.set_brightness = AsyncMock()
         mock_device.set_color_temperature = AsyncMock()
         mock_device.flash = AsyncMock(return_value=True)
+
+        # Track state change callbacks
+        callbacks = []
+        def on_state_change(cb):
+            if cb not in callbacks:
+                callbacks.append(cb)
+        def remove_state_listener(cb):
+            if cb in callbacks:
+                callbacks.remove(cb)
+        mock_device.on_state_change = MagicMock(side_effect=on_state_change)
+        mock_device.remove_state_listener = MagicMock(side_effect=remove_state_listener)
+        mock_device._state_callbacks = callbacks
+
+        def get_current_mock_state():
+            ret = mock_device.get_state.return_value
+            if isinstance(ret, dict):
+                return ret
+            return mock_device._current_state
+
+        def trigger_callbacks(old_state, new_state):
+            for cb in list(callbacks):
+                cb(mock_device, old_state, new_state)
+
+        async def mock_turn_on():
+            state = get_current_mock_state()
+            old = copy.deepcopy(state)
+            state["on"] = True
+            trigger_callbacks(old, copy.deepcopy(state))
+        mock_device.turn_on.side_effect = mock_turn_on
+
+        async def mock_turn_off():
+            state = get_current_mock_state()
+            old = copy.deepcopy(state)
+            state["on"] = False
+            trigger_callbacks(old, copy.deepcopy(state))
+        mock_device.turn_off.side_effect = mock_turn_off
+
+        async def mock_toggle():
+            state = get_current_mock_state()
+            old = copy.deepcopy(state)
+            state["on"] = not state.get("on", False)
+            trigger_callbacks(old, copy.deepcopy(state))
+        mock_device.toggle.side_effect = mock_toggle
+
+        async def mock_set_brightness(b):
+            state = get_current_mock_state()
+            old = copy.deepcopy(state)
+            state["brightness"] = b
+            trigger_callbacks(old, copy.deepcopy(state))
+        mock_device.set_brightness.side_effect = mock_set_brightness
+
+        async def mock_set_color_temp(k):
+            state = get_current_mock_state()
+            old = copy.deepcopy(state)
+            if "color" not in state:
+                state["color"] = {}
+            state["color"]["temperature"] = k
+            trigger_callbacks(old, copy.deepcopy(state))
+        mock_device.set_color_temperature.side_effect = mock_set_color_temp
+
         yield mock_device
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -464,3 +464,75 @@ async def test_light_toggle_error(hass, mock_dlight_device, mock_config_entry):
         await entity.async_toggle()
 
     mock_dlight_device.toggle.assert_called_once()
+
+
+async def test_turn_on_with_brightness_while_off_sends_power_command(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Regression: turn_on(brightness=X) while lamp is off must send turn_on().
+
+    Previously, optimistic state (_optimistic_on=True) was written before the
+    command list was assembled.  The guard `if not commands or not self.is_on`
+    then read the already-mutated optimistic value (True), so the explicit
+    turn_on() power command was never inserted when brightness was provided —
+    leaving a powered-off lamp receiving only a set_brightness call.
+    """
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Turn the lamp off first so is_on is False.
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {"entity_id": "light.test_light"}, blocking=True
+    )
+    assert hass.states.get("light.test_light").state == "off"
+    mock_dlight_device.turn_on.reset_mock()
+
+    # Now call turn_on WITH a brightness argument while the lamp is still off.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "brightness": 128},
+        blocking=True,
+    )
+
+    # The explicit power-on command MUST have been sent even though brightness
+    # was supplied (brightness alone doesn't power the lamp on).
+    mock_dlight_device.turn_on.assert_called_once()
+    # ceil(128 / 255 * 100) = 51
+    mock_dlight_device.set_brightness.assert_called_with(51)
+
+
+async def test_turn_on_with_kelvin_while_off_sends_power_command(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Regression: turn_on(color_temp_kelvin=K) while off must still send turn_on().
+
+    Companion to the brightness variant above — covers the same was_on bug for
+    a colour-temperature-only turn_on call.
+    """
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Turn off first.
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {"entity_id": "light.test_light"}, blocking=True
+    )
+    assert hass.states.get("light.test_light").state == "off"
+    mock_dlight_device.turn_on.reset_mock()
+
+    # Call turn_on with only a colour temperature while the lamp is off.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "color_temp_kelvin": 3000},
+        blocking=True,
+    )
+
+    # turn_on() must be in the command batch regardless of optimistic overrides.
+    mock_dlight_device.turn_on.assert_called_once()
+    mock_dlight_device.set_color_temperature.assert_called_with(3000)
+

--- a/tests/test_state_sync.py
+++ b/tests/test_state_sync.py
@@ -1,0 +1,54 @@
+"""Tests for the dLight state change listener integration."""
+from homeassistant.core import HomeAssistant
+from .conftest import setup_integration
+
+
+async def test_listener_registration_on_setup(
+    hass: HomeAssistant, mock_dlight_device, mock_config_entry
+):
+    """Test that the state change listener is registered on setup."""
+    await setup_integration(hass, mock_config_entry)
+    mock_dlight_device.on_state_change.assert_called_once()
+
+
+async def test_listener_unregistration_on_unload(
+    hass: HomeAssistant, mock_dlight_device, mock_config_entry
+):
+    """Test that the state change listener is removed when the config entry is unloaded."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Unload the config entry
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_dlight_device.remove_state_listener.assert_called_once()
+
+
+async def test_listener_propagates_state_change(
+    hass: HomeAssistant, mock_dlight_device, mock_config_entry
+):
+    """Test that state changes from the listener update the coordinator and entity state."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    # Initially, brightness is 50% = 128 HA scale
+    state = hass.states.get("light.test_light")
+    assert state.state == "on"
+    assert state.attributes.get("brightness") == 128
+
+    # Simulate a listener event from the device (e.g. brightness set to 80%)
+    old_state = {"on": True, "brightness": 50, "color": {"temperature": 4000}}
+    new_state = {"on": True, "brightness": 80, "color": {"temperature": 4000}}
+
+    # Call the listener callbacks
+    for cb in mock_dlight_device._state_callbacks:
+        cb(mock_dlight_device, old_state, new_state)
+    await hass.async_block_till_done()
+
+    # The coordinator data should be updated
+    assert coordinator.data == new_state
+
+    # The entity state should be updated to 204 (80% of 255)
+    state = hass.states.get("light.test_light")
+    assert state.state == "on"
+    assert state.attributes.get("brightness") == 204


### PR DESCRIPTION
Simplify and improve state synchronization using DLightDevice.on_state_change()

### Context / Background
Currently, the integration updates the light entity state using an optimistic update mechanism in `light.py` to prevent UI "snap back" while waiting for the next coordinator poll (every 30 seconds). To reconcile the optimistic state with the true device state, the integration relied on scheduling manual `coordinator.async_request_refresh()` polling calls after every command service call. This introduced unnecessary TCP get_state requests to the lamp immediately following command execution.

Furthermore, because optimistic state was set after commands completed, race conditions could arise where a state change was processed mid-command, leading to incorrect calculations of the optimistic state.

### Solution
This change transitions the integration to use the state listener pattern introduced in `dlight-client` v2.0.0. By listening to state changes on the device, we push state updates directly to the coordinator as soon as the library finishes executing commands, ensuring our cached state is always in sync with the library's internal state.

Specific changes:
1. **Coordinator Listener**: Registers `self.device.on_state_change(self._handle_device_state_change)` during initialization in `coordinator.py`. When a state change notification is received, it updates the coordinator data via `self.async_set_updated_data()`.
2. **Setup / Unload**: Adds state listener unregistration on entry unload in `__init__.py` to prevent memory leaks.
3. **Simplified Entity Logic**: Removes manual `async_request_refresh()` poll requests from standard commands (`turn_on`, `turn_off`, `toggle`) and transition loops in `light.py`. Reconciliations now occur naturally via listener updates.
4. **Optimistic Race Condition Fix**: Reorders the optimistic state updates in `light.py` to be applied *before* executing commands. This ensures that synchronous listener notifications triggered during the command execution correctly match and immediately clear the optimistic state on success, avoiding race conditions.
5. **Testing**:
   - Updates `mock_dlight_device` in `tests/conftest.py` to simulate real-world state changes and callbacks.
   - Adds `tests/test_state_sync.py` to verify listener registration, unregistration on unload, and propagation of state changes.

### Verification
Ran the test suite locally:
`PYTHONPATH=. python3 -m pytest`
All 47 tests passed successfully.
