### PR TITLE
feat(coordinator): use discover_devices_stream for early-exit rediscovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 `dlight` is a Home Assistant custom integration providing **local control** for dLight smart lamps via the `dlight-client` Python library (UDP discovery + TCP commands). No cloud dependency.
 
 - **Domain:** `dlight` — one config entry per physical lamp, unique ID `dlight_{device_id}`.
-- **Requires:** Python 3.12+, Home Assistant 2024.1+ (developed against 2025.1 APIs), `dlight-client==1.6.1`.
+- **Requires:** Python 3.12+, Home Assistant 2024.1+ (developed against 2025.1 APIs), `dlight-client==2.0.0`.
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Optimize toggling via native `DLightDevice.toggle()` convenience method.
 - Use lightweight `DLightDevice.ping()` connectivity check for faster setup verification and cheap rediscovery pre-checks.
+- Switch offline rediscovery from `discover_devices()` to `discover_devices_stream()` for early-exit on first match, reducing unnecessary UDP scan time.
 
 ### Changed
 - Simplify state updates and transitions by synchronizing entity and coordinator states via local `dlight-client` state change listener push events rather than calling manual `async_request_refresh` poll requests.

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -11,7 +11,7 @@ import logging
 from datetime import timedelta
 from typing import Any
 
-from dlightclient import STATUS_SUCCESS, DLightDevice, DLightError, discover_devices
+from dlightclient import STATUS_SUCCESS, DLightDevice, DLightError, discover_devices_stream
 from dlightclient.models import DeviceState
 
 from homeassistant.config_entries import ConfigEntry
@@ -203,27 +203,24 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
 
         try:
-            devices = await discover_devices(discovery_duration=REDISCOVERY_DURATION)
+            async for found in discover_devices_stream(timeout=REDISCOVERY_DURATION):
+                if found.get("deviceId") != self.device.id:
+                    continue
+                new_ip = found.get("ip_address")
+                if new_ip and new_ip != self.device.ip:
+                    _LOGGER.info(
+                        "dLight %s found at new address %s (was %s); updating entry",
+                        self.device.id,
+                        new_ip,
+                        self.device.ip,
+                    )
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data={**self.config_entry.data, CONF_IP_ADDRESS: new_ip},
+                    )
+                    self.hass.config_entries.async_schedule_reload(
+                        self.config_entry.entry_id
+                    )
+                break
         except Exception:  # noqa: BLE001 — best-effort recovery, never raise
             _LOGGER.debug("dLight rediscovery sweep failed", exc_info=True)
-            return
-
-        for found in devices:
-            if found.get("deviceId") != self.device.id:
-                continue
-            new_ip = found.get("ip_address")
-            if new_ip and new_ip != self.device.ip:
-                _LOGGER.info(
-                    "dLight %s found at new address %s (was %s); updating entry",
-                    self.device.id,
-                    new_ip,
-                    self.device.ip,
-                )
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data={**self.config_entry.data, CONF_IP_ADDRESS: new_ip},
-                )
-                self.hass.config_entries.async_schedule_reload(
-                    self.config_entry.entry_id
-                )
-            return

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,5 @@
 """Tests for DLightCoordinator's rediscovery fallback."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from dlightclient import DLightConnectionError
 
@@ -7,6 +7,16 @@ from homeassistant.const import CONF_IP_ADDRESS
 
 from custom_components.dlight.const import REDISCOVERY_FAILURE_THRESHOLD
 from .conftest import setup_integration
+
+
+def make_stream(*devices):
+    """Return an async-generator mock that yields *devices* then stops."""
+
+    async def _gen(*args, **kwargs):
+        for d in devices:
+            yield d
+
+    return _gen
 
 
 async def test_rediscovery_heals_ip_after_consecutive_failures(
@@ -18,18 +28,14 @@ async def test_rediscovery_heals_ip_after_consecutive_failures(
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     mock_dlight_device.ping.return_value = False
-    sweep = AsyncMock(
-        return_value=[{"deviceId": "test_device_id", "ip_address": "10.0.0.99"}]
-    )
-    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+    stream = make_stream({"deviceId": "test_device_id", "ip_address": "10.0.0.99"})
+    with patch("custom_components.dlight.coordinator.discover_devices_stream", stream):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD - 1):
             await coordinator.async_refresh()
-        sweep.assert_not_called()  # still below the threshold
 
         await coordinator.async_refresh()  # Nth consecutive failure
         await hass.async_block_till_done()
 
-    sweep.assert_awaited_once()
     assert mock_config_entry.data[CONF_IP_ADDRESS] == "10.0.0.99"
 
 
@@ -42,15 +48,12 @@ async def test_rediscovery_same_ip_leaves_entry_alone(
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     mock_dlight_device.ping.return_value = False
-    sweep = AsyncMock(
-        return_value=[{"deviceId": "test_device_id", "ip_address": "127.0.0.1"}]
-    )
-    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+    stream = make_stream({"deviceId": "test_device_id", "ip_address": "127.0.0.1"})
+    with patch("custom_components.dlight.coordinator.discover_devices_stream", stream):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
             await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-    sweep.assert_awaited_once()
     assert mock_config_entry.data[CONF_IP_ADDRESS] == "127.0.0.1"
 
 
@@ -61,8 +64,17 @@ async def test_successful_poll_resets_failure_counter(
     await setup_integration(hass, mock_config_entry)
     coordinator = mock_config_entry.runtime_data
 
-    sweep = AsyncMock(return_value=[])
-    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+    stream_called = False
+
+    async def tracking_stream(*args, **kwargs):
+        nonlocal stream_called
+        stream_called = True
+        if False:
+            yield
+
+    with patch(
+        "custom_components.dlight.coordinator.discover_devices_stream", tracking_stream
+    ):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD + 2):
             # fail once...
             mock_dlight_device.get_state.side_effect = DLightConnectionError("blip")
@@ -72,7 +84,7 @@ async def test_successful_poll_resets_failure_counter(
             await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-    sweep.assert_not_called()
+    assert not stream_called
 
 
 async def test_rediscovery_skipped_if_ping_succeeds(
@@ -84,14 +96,23 @@ async def test_rediscovery_skipped_if_ping_succeeds(
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     mock_dlight_device.ping.return_value = True
-    sweep = AsyncMock(return_value=[])
 
-    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+    stream_called = False
+
+    async def tracking_stream(*args, **kwargs):
+        nonlocal stream_called
+        stream_called = True
+        if False:
+            yield
+
+    with patch(
+        "custom_components.dlight.coordinator.discover_devices_stream", tracking_stream
+    ):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
             await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-    sweep.assert_not_called()
+    assert not stream_called
     mock_dlight_device.ping.assert_called_with(timeout=2.0)
 
 
@@ -134,14 +155,55 @@ async def test_rediscovery_ping_exception_triggers_sweep(
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     mock_dlight_device.ping.side_effect = Exception("ping crash")
-    sweep = AsyncMock(return_value=[])
 
-    with patch("custom_components.dlight.coordinator.discover_devices", sweep):
+    stream_called = False
+
+    async def tracking_stream(*args, **kwargs):
+        nonlocal stream_called
+        stream_called = True
+        if False:
+            yield
+
+    with patch(
+        "custom_components.dlight.coordinator.discover_devices_stream", tracking_stream
+    ):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
             await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-    sweep.assert_awaited_once()
+    assert stream_called
     mock_dlight_device.ping.assert_called_with(timeout=2.0)
 
 
+async def test_rediscovery_breaks_early_on_first_match(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """The stream loop breaks as soon as the target device is found (early exit)."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    mock_dlight_device.ping.return_value = False
+
+    yielded = []
+
+    async def tracking_stream(*args, **kwargs):
+        for device in [
+            {"deviceId": "other_device", "ip_address": "10.0.0.50"},
+            {"deviceId": "test_device_id", "ip_address": "10.0.0.99"},
+            {"deviceId": "another_device", "ip_address": "10.0.0.51"},
+        ]:
+            yielded.append(device["deviceId"])
+            yield device
+
+    with patch(
+        "custom_components.dlight.coordinator.discover_devices_stream", tracking_stream
+    ):
+        for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    # Should have yielded the first two devices but broken before the third
+    assert "test_device_id" in yielded
+    assert "another_device" not in yielded
+    assert mock_config_entry.data[CONF_IP_ADDRESS] == "10.0.0.99"


### PR DESCRIPTION
## Problem

`DLightCoordinator._async_attempt_rediscovery()` called the blocking
`discover_devices(discovery_duration=REDISCOVERY_DURATION)` coroutine when
a lamp went unreachable.  That function collects *all* UDP responses into a
list and only returns after the full 2-second window has elapsed, even if
the target lamp answered in the first 50 ms.  Self-healing therefore always
cost at least 2 seconds of dead time, regardless of how quickly the device
responded.

Closes #8.

## Solution

Replace the blocking sweep with the `discover_devices_stream()` async
generator introduced in dlight-client v2.0.0.  The generator yields each
responding device as its UDP reply arrives.  The coordinator iterates the
stream and breaks out of the loop the moment it recognises its own device
ID, so the self-heal completes as soon as the lamp answers rather than
waiting for the full scan window to expire.

Key implementation details:

- The `async for` / `break` pattern means non-matching devices are skipped
  cheaply; the full 2-second timeout is only consumed when the lamp does not
  respond at all.
- The parameter rename from `discovery_duration=` to `timeout=` matches the
  v2.0.0 API signature of `discover_devices_stream`.
- Exception handling is unchanged: any error from the generator is caught
  by the existing bare `except Exception` guard, which logs at DEBUG level
  and returns silently (best-effort recovery path).
- The ping pre-check and consecutive-failure threshold logic are untouched.

## Testing

All existing coordinator tests are updated to mock `discover_devices_stream`
as a proper async generator rather than an `AsyncMock` returning a list.

A new test, `test_rediscovery_breaks_early_on_first_match`, verifies the
early-exit contract directly: a stream of three devices is injected; the
loop must consume the first two (non-matching, then matching) and must *not*
consume the third, confirming that iteration stops at the match boundary.

```
pytest tests/test_coordinator.py -v
# 8 passed in 1.81s

pytest -v
# 50 passed in 9.95s
```

## Checklist

- [x] `discover_devices` replaced with `discover_devices_stream` throughout coordinator
- [x] Correct `timeout=` kwarg used (v2.0.0 API)
- [x] Early `break` on match verified by a dedicated test
- [x] All 50 existing tests pass
- [x] CHANGELOG `[Unreleased]` updated