### PR TITLE
feat(light): fire dlight_physical_control event on external state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Fire a `dlight_physical_control` HA event when a poll detects a state change that was not initiated by Home Assistant, enabling automations that respond to physical button presses or external control.
+
 ## [2.0.0] - 2026-06-14
 
 ### Added

--- a/custom_components/dlight/const.py
+++ b/custom_components/dlight/const.py
@@ -1,7 +1,9 @@
 """Constants for the dLight integration."""
+
 from homeassistant.const import Platform
 
 DOMAIN = "dlight"
+EVENT_PHYSICAL_CONTROL = "dlight_physical_control"
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.LIGHT]
 
 # Extra config-entry key (the IP address uses HA's standard CONF_IP_ADDRESS).

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -20,6 +20,7 @@ emulated — a background task walks brightness/temperature toward the target
 in small steps. The task is cancelled by any newer command, so the latest
 request always wins.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -47,7 +48,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, KELVIN_MAX, KELVIN_MIN, POLL_INTERVAL
+from .const import DOMAIN, EVENT_PHYSICAL_CONTROL, KELVIN_MAX, KELVIN_MIN, POLL_INTERVAL
 from .coordinator import DLightCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -179,6 +180,10 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         # every new command cancels it before doing anything else.
         self._transition_task: asyncio.Task | None = None
 
+        # Snapshot of the last coordinator-confirmed state, used to detect
+        # physical changes between polls. None until the first poll is accepted.
+        self._last_confirmed_data: dict | None = None
+
         # The registry card is built once: coordinator.info is static
         # (fetched a single time at setup, see DLightCoordinator).
         device_info = DeviceInfo(
@@ -281,7 +286,9 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
         commands = []
         if brightness is not None:
-            commands.append(self.device.set_brightness(_to_dlight_brightness(brightness)))
+            commands.append(
+                self.device.set_brightness(_to_dlight_brightness(brightness))
+            )
         if kelvin is not None:
             commands.append(self.device.set_color_temperature(int(kelvin)))
         # Setting brightness/temperature implicitly powers the lamp on, so the
@@ -463,7 +470,9 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         transition: float,
     ) -> tuple[list[tuple[int | None, int | None]], float]:
         """Slice a transition into timed steps of interpolated values."""
-        count = max(1, min(round(transition / TRANSITION_STEP_INTERVAL), TRANSITION_MAX_STEPS))
+        count = max(
+            1, min(round(transition / TRANSITION_STEP_INTERVAL), TRANSITION_MAX_STEPS)
+        )
         interval = transition / count
         steps = _interpolate_steps(start_pct, end_pct, start_kelvin, end_kelvin, count)
         return steps, interval
@@ -535,6 +544,12 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 await self._transition_task
         self._transition_task = None
 
+    async def async_added_to_hass(self) -> None:
+        """Entity is live: snapshot coordinator state as the physical baseline."""
+        await super().async_added_to_hass()
+        if self.coordinator.data is not None:
+            self._last_confirmed_data = self.coordinator.data
+
     async def async_will_remove_from_hass(self) -> None:
         """Entity is going away: never leave a fade task running behind it."""
         await self._async_cancel_transition()
@@ -560,6 +575,10 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
              A matching poll means the lamp confirmed the command — clear
              the optimistic state immediately.  A mismatching poll is stale
              and is ignored so the UI doesn't snap back.
+
+        When a poll arrives outside the hold window and the state has changed
+        since the last confirmed update, a dlight_physical_control event is
+        fired on the HA event bus (physical button press or external client).
         """
         if self.coordinator.data is None:
             return  # failed poll; availability handling is CoordinatorEntity's job
@@ -568,10 +587,13 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             # wherever the lamp was when polled. The fade requests its own
             # refresh on completion.
             return
-        if (
+
+        within_hold = (
             self._optimistic_on is not None
             and time.monotonic() - self._last_command_time < POLL_INTERVAL
-        ):
+        )
+
+        if within_hold:
             data = self.coordinator.data
             polled_on = data.get("on")
             polled_brightness = data.get("brightness")
@@ -585,7 +607,10 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             if self._optimistic_on != polled_on:
                 matches = False
             if self._optimistic_brightness is not None:
-                if _to_dlight_brightness(self._optimistic_brightness) != polled_brightness:
+                if (
+                    _to_dlight_brightness(self._optimistic_brightness)
+                    != polled_brightness
+                ):
                     matches = False
             if (
                 self._optimistic_kelvin is not None
@@ -598,5 +623,58 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 # this poll to prevent the UI from snapping back to a stale
                 # value during rapid-fire interactions.
                 return
+            # Matching poll confirms the HA command — fall through to update.
+        else:
+            # Outside the hold window: any change was driven externally.
+            if self._last_confirmed_data is not None:
+                self._fire_physical_control_event(
+                    self._last_confirmed_data, self.coordinator.data
+                )
+
+        self._last_confirmed_data = self.coordinator.data
         self._clear_optimistic_state()
         super()._handle_coordinator_update()
+
+    @callback
+    def _fire_physical_control_event(self, prev: dict, new: dict) -> None:
+        """Fire EVENT_PHYSICAL_CONTROL when a poll reveals an external state change."""
+        prev_on = prev.get("on")
+        new_on = new.get("on")
+        prev_brightness = prev.get("brightness")
+        new_brightness = new.get("brightness")
+        prev_kelvin = (
+            prev.get("color", {}).get("temperature")
+            if isinstance(prev.get("color"), dict)
+            else None
+        )
+        new_kelvin = (
+            new.get("color", {}).get("temperature")
+            if isinstance(new.get("color"), dict)
+            else None
+        )
+
+        if (
+            prev_on == new_on
+            and prev_brightness == new_brightness
+            and prev_kelvin == new_kelvin
+        ):
+            return  # poll was a no-op; nothing to report
+
+        if prev_on != new_on:
+            action = "turned_on" if new_on else "turned_off"
+        else:
+            action = "changed"
+
+        self.hass.bus.async_fire(
+            EVENT_PHYSICAL_CONTROL,
+            {
+                "device_id": self.device.id,
+                "entity_id": self.entity_id,
+                "action": action,
+                "previous_state": prev,
+                "new_state": new,
+            },
+        )
+        _LOGGER.debug(
+            "dLight %s: physical control detected (%s)", self.device.id, action
+        )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -4,7 +4,8 @@ import pytest
 from unittest.mock import patch
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
-from custom_components.dlight.const import DOMAIN
+from custom_components.dlight.const import DOMAIN, EVENT_PHYSICAL_CONTROL
+
 
 async def test_light_setup(hass, mock_dlight_device, mock_config_entry):
     """Test setting up the dLight light platform."""
@@ -19,16 +20,18 @@ async def test_light_setup(hass, mock_dlight_device, mock_config_entry):
     state = hass.states.get("light.test_light")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes.get("brightness") == 128 # 50% of 255 is ~128
+    assert state.attributes.get("brightness") == 128  # 50% of 255 is ~128
     assert state.attributes.get("color_temp_kelvin") == 4000
     assert state.attributes.get("friendly_name") == "Test Light"
 
     # Verify MAC address in device info
     from homeassistant.helpers import device_registry as dr
+
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test_device_id")})
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff") in device.connections
+
 
 async def test_light_turn_on(hass, mock_dlight_device, mock_config_entry):
     """Test turning on the dLight light."""
@@ -39,25 +42,30 @@ async def test_light_turn_on(hass, mock_dlight_device, mock_config_entry):
         await hass.async_block_till_done()
 
     # Update mock to reflect expected state after commands
-    mock_dlight_device.get_state.return_value = {"on": True, "brightness": 100, "color": {"temperature": 3000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 100,
+        "color": {"temperature": 3000},
+    }
 
     # Call turn_on service
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
         {"entity_id": "light.test_light", "brightness": 255, "color_temp_kelvin": 3000},
-        blocking=True
+        blocking=True,
     )
 
     # Verify device methods were called
-    mock_dlight_device.set_brightness.assert_called_with(100) # 255 is 100%
+    mock_dlight_device.set_brightness.assert_called_with(100)  # 255 is 100%
     mock_dlight_device.set_color_temperature.assert_called_with(3000)
-    
+
     # Verify state
     state = hass.states.get("light.test_light")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 255
     assert state.attributes.get("color_temp_kelvin") == 3000
+
 
 async def test_light_turn_off(hass, mock_dlight_device, mock_config_entry):
     """Test turning off the dLight light."""
@@ -68,22 +76,24 @@ async def test_light_turn_off(hass, mock_dlight_device, mock_config_entry):
         await hass.async_block_till_done()
 
     # Update mock to reflect expected state after commands
-    mock_dlight_device.get_state.return_value = {"on": False, "brightness": 0, "color": {"temperature": 3000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 3000},
+    }
 
     # Call turn_off service
     await hass.services.async_call(
-        LIGHT_DOMAIN,
-        "turn_off",
-        {"entity_id": "light.test_light"},
-        blocking=True
+        LIGHT_DOMAIN, "turn_off", {"entity_id": "light.test_light"}, blocking=True
     )
 
     # Verify device method was called
     mock_dlight_device.turn_off.assert_called_once()
-    
+
     # Verify state
     state = hass.states.get("light.test_light")
     assert state.state == "off"
+
 
 async def test_light_poll_update(hass, mock_dlight_device, mock_config_entry):
     """Test that the entity updates its state after a poll."""
@@ -102,7 +112,11 @@ async def test_light_poll_update(hass, mock_dlight_device, mock_config_entry):
     assert state.attributes.get("brightness") == 128
 
     # Change mock return value for the next poll
-    mock_dlight_device.get_state.return_value = {"on": True, "brightness": 80, "color": {"temperature": 5000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 80,
+        "color": {"temperature": 5000},
+    }
 
     # Trigger poll
     await coordinator.async_refresh()
@@ -111,8 +125,9 @@ async def test_light_poll_update(hass, mock_dlight_device, mock_config_entry):
     # Verify updated state
     state = hass.states.get("light.test_light")
     assert state.state == "on"
-    assert state.attributes.get("brightness") == 204 # 80% of 255 is 204
+    assert state.attributes.get("brightness") == 204  # 80% of 255 is 204
     assert state.attributes.get("color_temp_kelvin") == 5000
+
 
 async def test_light_coordinator_error(hass, mock_dlight_device, mock_config_entry):
     """Test that the entity becomes unavailable when polling fails."""
@@ -131,7 +146,10 @@ async def test_light_coordinator_error(hass, mock_dlight_device, mock_config_ent
     # Mock a connection error during the state poll (info is only fetched
     # once at setup, so it plays no part in ongoing availability)
     from dlightclient import DLightConnectionError
-    mock_dlight_device.get_state.side_effect = DLightConnectionError("Connection failed")
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError(
+        "Connection failed"
+    )
 
     # Trigger poll
     await coordinator.async_refresh()
@@ -141,13 +159,17 @@ async def test_light_coordinator_error(hass, mock_dlight_device, mock_config_ent
     state = hass.states.get("light.test_light")
     assert state.state == "unavailable"
 
-async def test_light_setup_with_info_failure(hass, mock_dlight_device, mock_config_entry):
+
+async def test_light_setup_with_info_failure(
+    hass, mock_dlight_device, mock_config_entry
+):
     """A failed device info query must not block entity creation.
 
     Info is cosmetic (registry card); the entity should still appear with a
     generic model as long as the state poll works.
     """
     from dlightclient import DLightConnectionError
+
     mock_dlight_device.get_info.side_effect = DLightConnectionError("info offline")
     mock_config_entry.add_to_hass(hass)
 
@@ -159,6 +181,7 @@ async def test_light_setup_with_info_failure(hass, mock_dlight_device, mock_conf
     assert state is not None
     assert state.state == "on"
     assert state.attributes.get("brightness") == 128
+
 
 async def test_light_turn_on_no_args(hass, mock_dlight_device, mock_config_entry):
     """Test turning on the light without any extra arguments."""
@@ -178,7 +201,11 @@ async def test_light_turn_on_no_args(hass, mock_dlight_device, mock_config_entry
     assert hass.states.get("light.test_light").state == "off"
 
     # Update mock to reflect expected state after turn_on
-    mock_dlight_device.get_state.return_value = {"on": True, "brightness": 100, "color": {"temperature": 3000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 100,
+        "color": {"temperature": 3000},
+    }
 
     # Now turn it on without args
     await hass.services.async_call(
@@ -189,9 +216,11 @@ async def test_light_turn_on_no_args(hass, mock_dlight_device, mock_config_entry
     mock_dlight_device.turn_on.assert_called_once()
     assert hass.states.get("light.test_light").state == "on"
 
+
 async def test_light_service_error(hass, mock_dlight_device, mock_config_entry):
     """Test that a HomeAssistantError is raised when a service call fails."""
     from homeassistant.exceptions import HomeAssistantError
+
     mock_config_entry.add_to_hass(hass)
 
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -209,7 +238,6 @@ async def test_light_service_error(hass, mock_dlight_device, mock_config_entry):
         )
 
 
-
 async def test_light_supports_transition(hass, mock_dlight_device, mock_config_entry):
     """The entity must advertise transition support (emulated fades)."""
     mock_config_entry.add_to_hass(hass)
@@ -219,9 +247,13 @@ async def test_light_supports_transition(hass, mock_dlight_device, mock_config_e
 
     state = hass.states.get("light.test_light")
     from homeassistant.components.light import LightEntityFeature
+
     assert state.attributes["supported_features"] & LightEntityFeature.TRANSITION
 
-async def test_light_turn_on_with_transition(hass, mock_dlight_device, mock_config_entry):
+
+async def test_light_turn_on_with_transition(
+    hass, mock_dlight_device, mock_config_entry
+):
     """A transition fades brightness/temperature in steps and lands on target."""
     mock_config_entry.add_to_hass(hass)
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -230,31 +262,52 @@ async def test_light_turn_on_with_transition(hass, mock_dlight_device, mock_conf
 
     # Initial confirmed state: on, 50%, 4000K. Fade to 100% / 3000K over 1s
     # -> 2 steps: (75%, 3500K) then (100%, 3000K).
-    mock_dlight_device.get_state.return_value = {"on": True, "brightness": 100, "color": {"temperature": 3000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 100,
+        "color": {"temperature": 3000},
+    }
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {"entity_id": "light.test_light", "brightness": 255, "color_temp_kelvin": 3000, "transition": 1},
+        {
+            "entity_id": "light.test_light",
+            "brightness": 255,
+            "color_temp_kelvin": 3000,
+            "transition": 1,
+        },
         blocking=True,
     )
     await hass.async_block_till_done()  # waits for the tracked fade task
 
-    assert [c.args[0] for c in mock_dlight_device.set_brightness.call_args_list] == [75, 100]
-    assert [c.args[0] for c in mock_dlight_device.set_color_temperature.call_args_list] == [3500, 3000]
+    assert [c.args[0] for c in mock_dlight_device.set_brightness.call_args_list] == [
+        75,
+        100,
+    ]
+    assert [
+        c.args[0] for c in mock_dlight_device.set_color_temperature.call_args_list
+    ] == [3500, 3000]
 
     state = hass.states.get("light.test_light")
     assert state.state == "on"
     assert state.attributes.get("brightness") == 255
     assert state.attributes.get("color_temp_kelvin") == 3000
 
-async def test_light_turn_off_with_transition(hass, mock_dlight_device, mock_config_entry):
+
+async def test_light_turn_off_with_transition(
+    hass, mock_dlight_device, mock_config_entry
+):
     """A turn_off transition fades brightness down before the power command."""
     mock_config_entry.add_to_hass(hass)
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    mock_dlight_device.get_state.return_value = {"on": False, "brightness": 0, "color": {"temperature": 4000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 4000},
+    }
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_off",
@@ -264,13 +317,18 @@ async def test_light_turn_off_with_transition(hass, mock_dlight_device, mock_con
     await hass.async_block_till_done()
 
     # From 50% in 2 steps: an intermediate dim, then the 1% floor, then off.
-    brightness_calls = [c.args[0] for c in mock_dlight_device.set_brightness.call_args_list]
+    brightness_calls = [
+        c.args[0] for c in mock_dlight_device.set_brightness.call_args_list
+    ]
     assert brightness_calls[-1] == 1
     assert all(0 < b < 50 for b in brightness_calls)
     mock_dlight_device.turn_off.assert_called_once()
     assert hass.states.get("light.test_light").state == "off"
 
-async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_device, mock_config_entry):
+
+async def test_light_transition_cancelled_by_new_command(
+    hass, mock_dlight_device, mock_config_entry
+):
     """A new command interrupts a running fade; no further steps are sent."""
     mock_config_entry.add_to_hass(hass)
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -285,7 +343,11 @@ async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_devic
         {"entity_id": "light.test_light", "brightness": 255, "transition": 20},
         blocking=True,
     )
-    mock_dlight_device.get_state.return_value = {"on": True, "brightness": 20, "color": {"temperature": 4000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 20,
+        "color": {"temperature": 4000},
+    }
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -295,7 +357,9 @@ async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_devic
     await hass.async_block_till_done()
 
     calls_after_cancel = len(mock_dlight_device.set_brightness.call_args_list)
-    assert mock_dlight_device.set_brightness.call_args_list[-1].args[0] == 20  # 51/255 -> 20%
+    assert (
+        mock_dlight_device.set_brightness.call_args_list[-1].args[0] == 20
+    )  # 51/255 -> 20%
     assert hass.states.get("light.test_light").attributes.get("brightness") == 51
 
     # Were the fade still alive, its next step would fire within 0.5s.
@@ -303,7 +367,10 @@ async def test_light_transition_cancelled_by_new_command(hass, mock_dlight_devic
     await hass.async_block_till_done()
     assert len(mock_dlight_device.set_brightness.call_args_list) == calls_after_cancel
 
-async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, mock_config_entry):
+
+async def test_rapid_fire_brightness_not_clobbered(
+    hass, mock_dlight_device, mock_config_entry
+):
     """Rapid brightness changes must not be reverted by a stale poll."""
     mock_config_entry.add_to_hass(hass)
 
@@ -323,7 +390,9 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
 
         # Command A: set brightness to ~40%
         mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 40, "color": {"temperature": 4000}
+            "on": True,
+            "brightness": 40,
+            "color": {"temperature": 4000},
         }
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -339,7 +408,9 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
         # processed B yet).
         fake_time = 1001.0
         mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 40, "color": {"temperature": 4000}
+            "on": True,
+            "brightness": 40,
+            "color": {"temperature": 4000},
         }
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -357,7 +428,9 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
         # no need to wait for the hold window to expire.
         fake_time = 1005.0
         mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 80, "color": {"temperature": 4000}
+            "on": True,
+            "brightness": 80,
+            "color": {"temperature": 4000},
         }
         await coordinator.async_refresh()
         await hass.async_block_till_done()
@@ -367,7 +440,9 @@ async def test_rapid_fire_brightness_not_clobbered(hass, mock_dlight_device, moc
         assert state.attributes.get("brightness") == 204
 
 
-async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, mock_config_entry):
+async def test_single_command_poll_clears_optimistic(
+    hass, mock_dlight_device, mock_config_entry
+):
     """A matching poll within the hold window clears optimistic state immediately."""
     mock_config_entry.add_to_hass(hass)
 
@@ -388,7 +463,9 @@ async def test_single_command_poll_clears_optimistic(hass, mock_dlight_device, m
         # Single command: set brightness to 100%.
         # The immediate poll returns 100% (lamp processed it quickly).
         mock_dlight_device.get_state.return_value = {
-            "on": True, "brightness": 100, "color": {"temperature": 4000}
+            "on": True,
+            "brightness": 100,
+            "color": {"temperature": 4000},
         }
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -427,7 +504,11 @@ async def test_light_toggle(hass, mock_dlight_device, mock_config_entry):
     assert entity is not None
 
     # Update mock to reflect expected state after toggle (turned off)
-    mock_dlight_device.get_state.return_value = {"on": False, "brightness": 0, "color": {"temperature": 4000}}
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 4000},
+    }
 
     # Call async_toggle directly on the entity.
     # Note: We call async_toggle directly because Home Assistant's component-level
@@ -446,6 +527,7 @@ async def test_light_toggle(hass, mock_dlight_device, mock_config_entry):
 async def test_light_toggle_error(hass, mock_dlight_device, mock_config_entry):
     """Test that toggle service raises HomeAssistantError on device error."""
     from homeassistant.exceptions import HomeAssistantError
+
     mock_config_entry.add_to_hass(hass)
 
     with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
@@ -536,3 +618,241 @@ async def test_turn_on_with_kelvin_while_off_sends_power_command(
     mock_dlight_device.turn_on.assert_called_once()
     mock_dlight_device.set_color_temperature.assert_called_with(3000)
 
+
+# ---------------------------------------------------------------------------
+# Physical button press / external control event tests (issue #18)
+# ---------------------------------------------------------------------------
+
+
+async def test_physical_control_event_fires_on_external_off(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """A poll detecting the lamp turned off without any HA command fires the event."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # async_added_to_hass initializes _last_confirmed_data from coordinator.data
+    # (the state fetched during async_config_entry_first_refresh), so a single
+    # external-change poll is enough to detect the difference.
+    coordinator = mock_config_entry.runtime_data
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # No HA command was issued, so _optimistic_on is None → outside hold window.
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    data = events[0].data
+    assert data["action"] == "turned_off"
+    assert data["device_id"] == "test_device_id"
+    assert data["entity_id"] == "light.test_light"
+    assert data["previous_state"]["on"] is True
+    assert data["new_state"]["on"] is False
+
+
+async def test_physical_control_event_fires_on_external_on(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """A poll detecting the lamp turned on without any HA command fires the event."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    # First confirm the lamp as off (no HA command, just a poll).
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # Physical button press turns it on.
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 100,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["action"] == "turned_on"
+
+
+async def test_physical_control_event_fires_on_brightness_change(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """A poll showing brightness change (lamp stays on) fires action='changed'."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # Lamp stays on but someone physically changed brightness to 80%.
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 80,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    data = events[0].data
+    assert data["action"] == "changed"
+    assert data["new_state"]["brightness"] == 80
+    assert data["previous_state"]["brightness"] == 50
+
+
+async def test_physical_control_not_fired_on_first_poll(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """No event fires during integration setup even though a baseline is established.
+
+    async_added_to_hass snapshots coordinator.data (from async_config_entry_first_refresh)
+    as the initial _last_confirmed_data. No coordinator refresh fires during setup, so
+    no state comparison happens and no event is dispatched.
+    """
+    events = []
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        # Register listener before setup so it captures any event from first_refresh.
+        hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert events == []
+
+
+async def test_physical_control_not_fired_within_hold_window(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """No event fires for a state change caused by an HA service call."""
+    mock_config_entry.add_to_hass(hass)
+
+    fake_time = 1000.0
+
+    def monotonic():
+        return fake_time
+
+    with patch("custom_components.dlight.light.time") as mock_time:
+        mock_time.monotonic = monotonic
+
+        with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        coordinator = mock_config_entry.runtime_data
+
+        events = []
+        hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+        # HA sends a turn_off; _last_command_time is set to fake_time=1000.
+        mock_dlight_device.get_state.return_value = {
+            "on": False,
+            "brightness": 0,
+            "color": {"temperature": 4000},
+        }
+        await hass.services.async_call(
+            LIGHT_DOMAIN, "turn_off", {"entity_id": "light.test_light"}, blocking=True
+        )
+
+        # Poll at the same fake_time → within hold window (0s elapsed < 30s).
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        assert events == []
+
+
+async def test_physical_control_not_fired_when_state_unchanged(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """No event fires when successive outside-window polls return identical state."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # Two polls — same state as the initial confirmed data.
+    for _ in range(2):
+        mock_dlight_device.get_state.return_value = {
+            "on": True,
+            "brightness": 50,
+            "color": {"temperature": 4000},
+        }
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    assert events == []
+
+
+async def test_physical_control_not_fired_during_transition(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """No event fires while an emulated fade transition is active."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    entity = hass.data["light"].get_entity("light.test_light")
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # Start a 20-second fade — the task runs in the background and is sleeping
+    # between steps. asyncio.sleep uses real wall time, so async_block_till_done
+    # would wait up to 20 real seconds if not cancelled first.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "brightness": 255, "transition": 20},
+        blocking=True,
+    )
+    assert entity._transition_task is not None and not entity._transition_task.done()
+
+    # Poll while the fade is active — simulating an external state change.
+    # coordinator.async_refresh() awaits completion synchronously; by the time it
+    # returns, _handle_coordinator_update has already been called and returned early
+    # (transition guard), so no event has been scheduled.
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 0,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+
+    # Assert immediately — before calling async_block_till_done, which would
+    # wait for the 20-second fade to complete and might trigger post-fade logic.
+    assert events == []
+
+    # Cleanup: cancel the fade so the test doesn't block for 20 real seconds.
+    await entity._async_cancel_transition()


### PR DESCRIPTION
## Summary

Closes #18.

- Adds a `dlight_physical_control` event fired on the HA event bus whenever a coordinator poll detects a state change that was **not** initiated by Home Assistant (physical button press, external app, etc.).
- `DLightEntity.async_added_to_hass` now snapshots the initial coordinator state as the physical baseline, so detection works from the very first poll after setup.
- Event payload includes `device_id`, `entity_id`, `action` (`"turned_on"` / `"turned_off"` / `"changed"`), `previous_state`, and `new_state` — giving automation authors everything they need to filter and act on specific changes.

### How detection works

The existing optimistic hold window already distinguishes HA-initiated from external changes:

- **Within hold window** (`_last_command_time` < 30 s ago and optimistic state pending) → HA sent the command; no event.
- **Outside hold window** → lamp state changed without an HA command in flight; fire `dlight_physical_control`.
- **Fade active** → coordinator updates are ignored until the fade finishes; no event.

### Example automation trigger

```yaml
trigger:
  - platform: event
    event_type: dlight_physical_control
    event_data:
      device_id: "abc123"
      action: "turned_off"
```

## Test plan

- [x] `test_physical_control_event_fires_on_external_off` — event fires with `action: turned_off`
- [x] `test_physical_control_event_fires_on_external_on` — event fires with `action: turned_on`
- [x] `test_physical_control_event_fires_on_brightness_change` — event fires with `action: changed`
- [x] `test_physical_control_not_fired_on_first_poll` — no event during initial setup
- [x] `test_physical_control_not_fired_within_hold_window` — no event for HA-initiated changes
- [x] `test_physical_control_not_fired_when_state_unchanged` — no event when state is identical
- [x] `test_physical_control_not_fired_during_transition` — no event while a fade is active
- [x] All 57 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)