### PR TITLE
ci: integrate Codecov and enforce 80% coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,8 +20,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-homeassistant-custom-component pytest-sugar
+          pip install pytest pytest-asyncio pytest-homeassistant-custom-component pytest-sugar pytest-cov
 
       - name: Run tests
         run: |
-          pytest
+          pytest --cov=custom_components/dlight --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://github.com/Irishsmurf/dlight-hass/actions/workflows/tests.yaml"><img src="https://github.com/Irishsmurf/dlight-hass/actions/workflows/tests.yaml/badge.svg" alt="Tests"></a>
   <a href="https://github.com/Irishsmurf/dlight-hass/actions/workflows/hassfest.yaml"><img src="https://github.com/Irishsmurf/dlight-hass/actions/workflows/hassfest.yaml/badge.svg" alt="Hassfest"></a>
   <a href="https://github.com/Irishsmurf/dlight-hass/actions/workflows/hacs.yaml"><img src="https://github.com/Irishsmurf/dlight-hass/actions/workflows/hacs.yaml/badge.svg" alt="HACS Action"></a>
+  <a href="https://codecov.io/gh/Irishsmurf/dlight-hass"><img src="https://codecov.io/gh/Irishsmurf/dlight-hass/branch/main/graph/badge.svg" alt="Coverage"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Adds `pytest-cov` to the test workflow and generates an XML coverage report on every CI run
- Uploads coverage reports to Codecov via `codecov/codecov-action@v4` (requires `CODECOV_TOKEN` repository secret)
- Adds `.codecov.yml` to enforce a minimum 80% project coverage threshold
- Adds Codecov badge to README

## Test plan
- [x] Verify `CODECOV_TOKEN` secret is set in repository settings
- [ ] Confirm CI run uploads coverage to Codecov after merge
- [ ] Confirm Codecov badge appears on README

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)