### PR TITLE
ci: optimize workflows and add Codecov Test Analytics

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,7 +1,6 @@
 name: Hassfest
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,13 @@ name: Tests
 
 on:
   push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 jobs:
   pytest:
@@ -15,19 +21,26 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-homeassistant-custom-component pytest-sugar pytest-cov
 
       - name: Run tests
         run: |
-          pytest --cov=custom_components/dlight --cov-report=xml
+          pytest --cov=custom_components/dlight --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install -r requirements.txt
 
       - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dlight-client==2.0.0
-pytest-homeassistant-custom-component==0.12.49
+pytest-homeassistant-custom-component==0.13.339
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dlight-client==2.0.0
-pytest
-pytest-asyncio
-pytest-homeassistant-custom-component
-pytest-sugar
-pytest-cov
+pytest==7.2.0
+pytest-asyncio==0.20.2
+pytest-homeassistant-custom-component==0.12.49
+pytest-sugar==0.9.5
+pytest-cov==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 dlight-client==2.0.0
-pytest-homeassistant-custom-component==0.13.339
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component
+pytest-sugar
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 dlight-client==2.0.0
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component
+pytest-sugar
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 dlight-client==2.0.0
-pytest==7.2.0
-pytest-asyncio==0.20.2
 pytest-homeassistant-custom-component==0.12.49
-pytest-sugar==0.9.5
-pytest-cov==3.0.0
+pytest-cov


### PR DESCRIPTION
## Summary

- Add pip cache to `tests.yaml` via `setup-python`'s built-in cache, keyed on `requirements.txt` — skips network downloads on unchanged deps
- Consolidate test packages into `requirements.txt` so the cache key covers everything and the install is a single call
- Add `paths-ignore` filters to skip the test job on doc/markdown-only pushes
- Add `--junitxml=junit.xml` output and `codecov/test-results-action@v1` for Codecov Test Analytics (run times, failure rates, flaky test detection)
- Remove `push` trigger from `hassfest.yaml` — PR + nightly schedule is sufficient; avoids redundant runs on every merge to main

## Test plan

- [ ] Push a commit and verify pip cache is created on first run, restored on subsequent runs
- [ ] Push a markdown-only change and confirm the test job is skipped
- [ ] Confirm `junit.xml` is generated and uploaded to Codecov Test Analytics
- [ ] Confirm Hassfest no longer triggers on direct pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)