### PR TITLE
feat(ci): integrate Codecov Flags for per-component coverage segmentation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,20 @@ coverage:
         target: 80%
         threshold: 0%
         if_ci_failed: error
+
+flags:
+  coordinator:
+    paths:
+      - custom_components/dlight/coordinator.py
+  config_flow:
+    paths:
+      - custom_components/dlight/config_flow.py
+  light:
+    paths:
+      - custom_components/dlight/light.py
+  button:
+    paths:
+      - custom_components/dlight/button.py
+  binary_sensor:
+    paths:
+      - custom_components/dlight/binary_sensor.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,11 +33,41 @@ jobs:
         run: |
           pytest --cov=custom_components/dlight --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov (aggregate)
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage — coordinator flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: coordinator
+
+      - name: Upload coverage — config_flow flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: config_flow
+
+      - name: Upload coverage — light flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: light
+
+      - name: Upload coverage — button flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: button
+
+      - name: Upload coverage — binary_sensor flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: binary_sensor
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Fire a `dlight_physical_control` HA event when a poll detects a state change that was not initiated by Home Assistant, enabling automations that respond to physical button presses or external control.
+- Integrate Codecov Flags (`coordinator`, `config_flow`, `light`, `button`, `binary_sensor`) for per-component coverage segmentation in CI.
 
 ## [2.0.0] - 2026-06-14
 


### PR DESCRIPTION
## Summary

- Adds a `flags` block to `.codecov.yml` defining five named Codecov Flags (`coordinator`, `config_flow`, `light`, `button`, `binary_sensor`), each mapped to its corresponding source file
- Extends `.github/workflows/tests.yaml` to upload coverage five additional times (once per flag) after the existing aggregate upload, enabling per-component coverage tracking on the Codecov dashboard and PR comments

Closes #22

## Test plan

- [ ] Push branch and verify CI passes
- [ ] Confirm Codecov PR comment shows per-flag coverage breakdown
- [ ] Check Codecov dashboard for individual flag coverage graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)