### PR TITLE
feat(ci): add Codecov component definitions for per-feature coverage tracking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,3 +22,34 @@ flags:
   binary_sensor:
     paths:
       - custom_components/dlight/binary_sensor.py
+
+component_management:
+  default_rules:
+    statuses:
+      - type: component
+        target: auto
+        threshold: 5%
+  individual_components:
+    - component_id: coordinator
+      name: Coordinator
+      paths:
+        - custom_components/dlight/coordinator.py
+    - component_id: config_flow
+      name: Config Flow
+      paths:
+        - custom_components/dlight/config_flow.py
+    - component_id: light_entity
+      name: Light Entity
+      paths:
+        - custom_components/dlight/light.py
+    - component_id: diagnostics
+      name: Diagnostics
+      paths:
+        - custom_components/dlight/binary_sensor.py
+        - custom_components/dlight/button.py
+        - custom_components/dlight/diagnostics.py
+    - component_id: integration_init
+      name: Integration Init
+      paths:
+        - custom_components/dlight/__init__.py
+        - custom_components/dlight/const.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Fire a `dlight_physical_control` HA event when a poll detects a state change that was not initiated by Home Assistant, enabling automations that respond to physical button presses or external control.
 - Integrate Codecov Flags (`coordinator`, `config_flow`, `light`, `button`, `binary_sensor`) for per-component coverage segmentation in CI.
+- Add Codecov component definitions (`coordinator`, `config_flow`, `light_entity`, `diagnostics`, `integration_init`) for per-feature coverage thresholds and targeted PR feedback.
 
 ## [2.0.0] - 2026-06-14
 


### PR DESCRIPTION
## Summary

- Adds a `component_management` block to `.codecov.yml` defining five named Codecov Components (`coordinator`, `config_flow`, `light_entity`, `diagnostics`, `integration_init`), each mapped to its corresponding source files
- Enforces per-component coverage thresholds with a default 5% tolerance and `target: auto`, giving actionable PR feedback at the component level rather than just an aggregate pass/fail

Closes #23

## Test plan

- [ ] Push branch and verify CI passes
- [ ] Confirm Codecov PR comment shows per-component coverage status
- [ ] Check Codecov dashboard for individual component coverage tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)