### PR TITLE
test(init): add lifecycle tests and fix client.close leak on failed setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Register `client.close` before `async_config_entry_first_refresh()` so the persistent TCP connection is always cleaned up, even when setup fails with `ConfigEntryNotReady`.
+
 ### Added
+- Add `tests/test_init.py` with 8 lifecycle tests covering setup, unload, client cleanup on success and failure, listener registration/removal, and missing-config error paths.
 - Add `EventEntity` (`event.py`) for physical control: physical button presses and external state changes now appear as a proper device entity in the HA UI (device class `button`, diagnostic category), in addition to the existing `dlight_physical_control` bus event. Supports event types `turned_on`, `turned_off`, and `changed`.
 - Add `docs/user-guide/physical-control-event.md` documenting the `dlight_physical_control` event: payload reference, automation examples, Physical Control entity usage, and limitations. Linked from `features.md`, `mkdocs.yml` nav, and `README.md`.
 

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -36,6 +36,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
     # Register close before the first refresh so the connection is always
     # cleaned up — even if async_config_entry_first_refresh raises
     # ConfigEntryNotReady and HA fires the unload hooks during retry teardown.
+    # HA's _async_process_on_unload schedules any returned coroutine as a task,
+    # so passing client.close (an async method) directly is correct.
     entry.async_on_unload(client.close)
 
     device = DLightDevice(ip_address=ip_address, device_id=device_id, client=client)

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -33,6 +33,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
         )
 
     client = AsyncDLightClient(persistent=True)
+    # Register close before the first refresh so the connection is always
+    # cleaned up — even if async_config_entry_first_refresh raises
+    # ConfigEntryNotReady and HA fires the unload hooks during retry teardown.
+    entry.async_on_unload(client.close)
+
     device = DLightDevice(ip_address=ip_address, device_id=device_id, client=client)
 
     coordinator = DLightCoordinator(
@@ -47,18 +52,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
     entry.runtime_data = coordinator
 
     # Register the push state listener only after a successful first refresh.
-    # This avoids a memory leak / reference cycle when setup fails: if
-    # async_config_entry_first_refresh raises, the unload hooks below are never
-    # called, so we must not have registered the listener yet.
+    # This avoids a ghost listener on the device object if setup fails and the
+    # coordinator is never fully initialised.
     coordinator.device.on_state_change(coordinator._handle_device_state_change)
     entry.async_on_unload(
         lambda: coordinator.device.remove_state_listener(
             coordinator._handle_device_state_change
         )
     )
-
-    # Ensure the persistent connection is closed when the entry is unloaded.
-    entry.async_on_unload(client.close)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,112 @@
+"""Tests for __init__.py: entry lifecycle, client cleanup, and listener registration."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from dlightclient import DLightConnectionError
+from homeassistant.config_entries import ConfigEntryNotReady
+from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.exceptions import ConfigEntryError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dlight.const import CONF_DEVICE_ID, DOMAIN
+from .conftest import setup_integration
+
+
+async def test_setup_entry_populates_runtime_data(hass, mock_dlight_device, mock_config_entry):
+    """Successful setup stores a coordinator in entry.runtime_data."""
+    await setup_integration(hass, mock_config_entry)
+    from custom_components.dlight.coordinator import DLightCoordinator
+    assert isinstance(mock_config_entry.runtime_data, DLightCoordinator)
+
+
+async def test_setup_entry_registers_state_listener(hass, mock_dlight_device, mock_config_entry):
+    """setup_entry registers the coordinator's push-state listener on the device."""
+    await setup_integration(hass, mock_config_entry)
+    mock_dlight_device.on_state_change.assert_called_once()
+
+
+async def test_unload_entry_closes_client(hass, mock_dlight_device, mock_config_entry):
+    """async_unload_entry triggers client.close() via the registered unload hook."""
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True) as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.close = AsyncMock()
+        mock_config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_client.close.assert_called_once()
+
+
+async def test_unload_entry_removes_state_listener(hass, mock_dlight_device, mock_config_entry):
+    """async_unload_entry removes the push-state listener from the device."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_dlight_device.remove_state_listener.assert_called_once()
+
+
+async def test_setup_entry_raises_config_entry_not_ready_on_failed_refresh(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """If the first coordinator refresh fails, ConfigEntryNotReady is raised."""
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("unreachable")
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert result is False
+    assert mock_config_entry.state.value == "setup_retry"
+
+
+async def test_setup_entry_closes_client_on_failed_refresh(hass, mock_dlight_device, mock_config_entry):
+    """If the first refresh fails, client.close() is still called (no connection leak)."""
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("unreachable")
+
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True) as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.close = AsyncMock()
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # client.close is registered as an unload hook — on failed setup the entry
+    # is torn down, which fires the hook.
+    mock_client.close.assert_called_once()
+
+
+async def test_setup_entry_raises_config_entry_error_on_missing_ip(hass, mock_dlight_device):
+    """ConfigEntryError is raised immediately when IP address is absent from entry data."""
+    bad_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_ID: "test_device_id"},  # no CONF_IP_ADDRESS
+        title="Bad Entry",
+        entry_id="bad_entry_id",
+    )
+    bad_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        result = await hass.config_entries.async_setup(bad_entry.entry_id)
+
+    assert result is False
+    assert bad_entry.state.value == "setup_error"
+
+
+async def test_setup_entry_raises_config_entry_error_on_missing_device_id(hass, mock_dlight_device):
+    """ConfigEntryError is raised immediately when device ID is absent from entry data."""
+    bad_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "127.0.0.1"},  # no CONF_DEVICE_ID
+        title="Bad Entry",
+        entry_id="bad_entry_id2",
+    )
+    bad_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        result = await hass.config_entries.async_setup(bad_entry.entry_id)
+
+    assert result is False
+    assert bad_entry.state.value == "setup_error"


### PR DESCRIPTION
## Summary

- Adds `tests/test_init.py` with 8 lifecycle tests covering the full `async_setup_entry` / `async_unload_entry` surface: runtime_data population, listener registration and removal, `client.close` on normal unload, `client.close` when `ConfigEntryNotReady` is raised, and `ConfigEntryError` on missing IP or device ID.
- **Bug fix:** moves `entry.async_on_unload(client.close)` to before `async_config_entry_first_refresh()` so the persistent TCP connection is always closed — even when HA puts the entry in `setup_retry` state.

Closes #27

## Test plan

- [x] All 8 new tests in `test_init.py` pass
- [x] `__init__.py` coverage reaches 100%
- [x] All 77 tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)