### PR TITLE
feat(binary_sensor): expose coordinator health metrics as extra state attributes

### DIFF
--- a/custom_components/dlight/binary_sensor.py
+++ b/custom_components/dlight/binary_sensor.py
@@ -7,6 +7,8 @@ dropping off the network (notify, retry, power-cycle a smart plug, ...).
 """
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -17,7 +19,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, POLL_INTERVAL, REDISCOVERY_FAILURE_THRESHOLD
 from .coordinator import DLightCoordinator
 
 # Read-only view over coordinator data; nothing to serialize.
@@ -69,3 +71,15 @@ class DLightConnectivitySensor(CoordinatorEntity[DLightCoordinator], BinarySenso
     def is_on(self) -> bool:
         """Return True while polls are reaching the lamp."""
         return self.coordinator.last_update_success
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose coordinator health metrics for dashboards and automations."""
+        coord = self.coordinator
+        last_poll = coord._last_successful_poll
+        return {
+            "consecutive_failures": coord._consecutive_failures,
+            "last_successful_poll": last_poll.isoformat() if last_poll else None,
+            "rediscovery_triggered": coord._consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD,
+            "poll_interval_seconds": POLL_INTERVAL,
+        }

--- a/custom_components/dlight/binary_sensor.py
+++ b/custom_components/dlight/binary_sensor.py
@@ -76,10 +76,9 @@ class DLightConnectivitySensor(CoordinatorEntity[DLightCoordinator], BinarySenso
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose coordinator health metrics for dashboards and automations."""
         coord = self.coordinator
-        last_poll = coord._last_successful_poll
         return {
-            "consecutive_failures": coord._consecutive_failures,
-            "last_successful_poll": last_poll.isoformat() if last_poll else None,
-            "rediscovery_triggered": coord._consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD,
+            "consecutive_failures": coord.consecutive_failures,
+            "last_successful_poll": coord.last_successful_poll,
+            "rediscovery_triggered": coord.consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD,
             "poll_interval_seconds": POLL_INTERVAL,
         }

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from dlightclient import STATUS_SUCCESS, DLightDevice, DLightError, discover_devices_stream
@@ -17,6 +17,7 @@ from dlightclient.models import DeviceState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -67,6 +68,7 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # most one UDP sweep in flight at a time.
         self._consecutive_failures = 0
         self._rediscovery_task: asyncio.Task | None = None
+        self._last_successful_poll: datetime | None = None
 
     @callback
     def _handle_device_state_change(
@@ -165,6 +167,7 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 f"Invalid state payload from dLight {self.device.id}: {state!r}"
             )
         self._consecutive_failures = 0
+        self._last_successful_poll = dt_util.utcnow()
         _LOGGER.debug("dLight %s: poll success on=%s brightness=%s", self.device.id, state.get("on"), state.get("brightness"))
         return state
 

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -70,6 +70,16 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._rediscovery_task: asyncio.Task | None = None
         self._last_successful_poll: datetime | None = None
 
+    @property
+    def consecutive_failures(self) -> int:
+        """Return the number of consecutive failed polls."""
+        return self._consecutive_failures
+
+    @property
+    def last_successful_poll(self) -> datetime | None:
+        """Return the timestamp of the last successful poll."""
+        return self._last_successful_poll
+
     @callback
     def _handle_device_state_change(
         self,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -68,7 +68,7 @@ async def test_connectivity_sensor_health_attributes_degraded(
         "binary_sensor", DOMAIN, "dlight_test_device_id_connectivity"
     )
     coordinator = mock_config_entry.runtime_data
-    last_good_poll = hass.states.get(entity_id).attributes["last_successful_poll"]
+    last_good_poll = coordinator.last_successful_poll
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     # Suppress rediscovery so the test doesn't trigger an entry reload.
@@ -79,10 +79,10 @@ async def test_connectivity_sensor_health_attributes_degraded(
 
     # Check coordinator state directly (entity state cache may only update on
     # last_update_success transitions, not every failure increment).
-    assert coordinator._consecutive_failures == REDISCOVERY_FAILURE_THRESHOLD
-    assert coordinator._last_successful_poll is not None
-    assert coordinator._last_successful_poll.isoformat() == last_good_poll
-    assert coordinator._consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD  # rediscovery_triggered
+    assert coordinator.consecutive_failures == REDISCOVERY_FAILURE_THRESHOLD
+    assert coordinator.last_successful_poll is not None
+    assert coordinator.last_successful_poll == last_good_poll
+    assert coordinator.consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD  # rediscovery_triggered
 
     # Recovery: failures reset, timestamp refreshes, rediscovery_triggered clears.
     mock_dlight_device.get_state.side_effect = None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -3,7 +3,7 @@ from dlightclient import DLightConnectionError
 
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.dlight.const import DOMAIN
+from custom_components.dlight.const import DOMAIN, POLL_INTERVAL, REDISCOVERY_FAILURE_THRESHOLD
 from .conftest import setup_integration
 
 
@@ -38,3 +38,81 @@ async def test_connectivity_sensor_tracks_poll_health(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == "on"
+
+
+async def test_connectivity_sensor_health_attributes_healthy(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Health attributes reflect zero failures and a timestamp after a good poll."""
+    await setup_integration(hass, mock_config_entry)
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", DOMAIN, "dlight_test_device_id_connectivity"
+    )
+    state = hass.states.get(entity_id)
+    attrs = state.attributes
+
+    assert attrs["consecutive_failures"] == 0
+    assert attrs["last_successful_poll"] is not None  # set by setup poll
+    assert attrs["rediscovery_triggered"] is False
+    assert attrs["poll_interval_seconds"] == POLL_INTERVAL
+
+
+async def test_connectivity_sensor_health_attributes_degraded(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """consecutive_failures increments on poll errors; rediscovery_triggered flips at threshold."""
+    from unittest.mock import patch as _patch
+
+    await setup_integration(hass, mock_config_entry)
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", DOMAIN, "dlight_test_device_id_connectivity"
+    )
+    coordinator = mock_config_entry.runtime_data
+    last_good_poll = hass.states.get(entity_id).attributes["last_successful_poll"]
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    # Suppress rediscovery so the test doesn't trigger an entry reload.
+    with _patch.object(coordinator, "_async_attempt_rediscovery", return_value=None):
+        for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+
+    # Check coordinator state directly (entity state cache may only update on
+    # last_update_success transitions, not every failure increment).
+    assert coordinator._consecutive_failures == REDISCOVERY_FAILURE_THRESHOLD
+    assert coordinator._last_successful_poll is not None
+    assert coordinator._last_successful_poll.isoformat() == last_good_poll
+    assert coordinator._consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD  # rediscovery_triggered
+
+    # Recovery: failures reset, timestamp refreshes, rediscovery_triggered clears.
+    mock_dlight_device.get_state.side_effect = None
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    attrs = hass.states.get(entity_id).attributes
+    assert attrs["consecutive_failures"] == 0
+    assert attrs["rediscovery_triggered"] is False
+    assert attrs["last_successful_poll"] != last_good_poll
+
+
+async def test_connectivity_sensor_last_successful_poll_none_before_first_success(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """last_successful_poll is None until the first poll succeeds."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    # Manually reset to simulate a coordinator that has never had a good poll.
+    coordinator._last_successful_poll = None
+    coordinator._consecutive_failures = 1
+
+    # Trigger a refresh that fails to keep the state consistent.
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", DOMAIN, "dlight_test_device_id_connectivity"
+    )
+    attrs = hass.states.get(entity_id).attributes
+    assert attrs["last_successful_poll"] is None


### PR DESCRIPTION
## Summary

- Adds `consecutive_failures`, `last_successful_poll`, `rediscovery_triggered`, and `poll_interval_seconds` to `DLightConnectivitySensor.extra_state_attributes`, enabling dashboards and automations to surface degraded-but-not-failed connections.
- Coordinator now tracks `_last_successful_poll` (a `datetime`, set via `dt_util.utcnow()` on each successful poll, `None` until first success).

Closes #32

## Test plan

- [ ] Healthy state: all four attributes present with `consecutive_failures=0` and a non-null `last_successful_poll`
- [ ] Degraded state: `consecutive_failures` increments, `last_successful_poll` frozen, `rediscovery_triggered` flips at threshold
- [ ] Recovery: failures reset, timestamp refreshes, `rediscovery_triggered` clears
- [ ] `last_successful_poll` is `None` until first successful poll
- [ ] All existing tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)