### PR TITLE
feat(light): add MIN_BRIGHTNESS_PCT floor to prevent near-zero flicker

### DIFF
--- a/custom_components/dlight/const.py
+++ b/custom_components/dlight/const.py
@@ -26,3 +26,7 @@ REDISCOVERY_FAILURE_THRESHOLD = 3
 
 # How long a rediscovery sweep listens for UDP answers, in seconds.
 REDISCOVERY_DURATION = 2.0
+
+# Lamps are unreliable (flicker, brief power-cycle) below this brightness.
+# Applied as a floor to all turn_on and fade-step commands; turn_off is exempt.
+MIN_BRIGHTNESS_PCT = 5

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -48,7 +48,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, EVENT_PHYSICAL_CONTROL, KELVIN_MAX, KELVIN_MIN, POLL_INTERVAL
+from .const import DOMAIN, EVENT_PHYSICAL_CONTROL, KELVIN_MAX, KELVIN_MIN, MIN_BRIGHTNESS_PCT, POLL_INTERVAL
 from .coordinator import DLightCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,9 +63,6 @@ PARALLEL_UPDATES = 1
 # into command floods (the interval stretches instead).
 TRANSITION_STEP_INTERVAL = 0.5
 TRANSITION_MAX_STEPS = 60
-# Fade-to-off bottoms out here before the actual power-off command: 0% via
-# set_brightness is indistinguishable from "off" and would end the fade early.
-TRANSITION_MIN_OFF_PCT = 1
 
 
 def _to_ha_brightness(percent: int) -> int:
@@ -75,6 +72,11 @@ def _to_ha_brightness(percent: int) -> int:
     brightness must stay non-zero in HA (1% -> 3, never 0 = "off").
     """
     return math.ceil(percent / 100 * 255)
+
+
+def _apply_brightness_floor(pct: int) -> int:
+    """Clamp a device-percent brightness to MIN_BRIGHTNESS_PCT."""
+    return max(pct, MIN_BRIGHTNESS_PCT)
 
 
 def _to_dlight_brightness(brightness: int) -> int:
@@ -304,14 +306,16 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         if brightness is not None and kelvin is not None:
             commands.append(
                 self.device.apply_scene(
-                    brightness=_to_dlight_brightness(brightness),
+                    brightness=_apply_brightness_floor(_to_dlight_brightness(brightness)),
                     temperature=int(kelvin),
                 )
             )
         else:
             if brightness is not None:
                 commands.append(
-                    self.device.set_brightness(_to_dlight_brightness(brightness))
+                    self.device.set_brightness(
+                        _apply_brightness_floor(_to_dlight_brightness(brightness))
+                    )
                 )
             if kelvin is not None:
                 commands.append(self.device.set_color_temperature(int(kelvin)))
@@ -478,11 +482,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         already at minimum) so the caller sends a plain power-off instead.
         """
         start_pct = self._current_pct()
-        if not self.is_on or start_pct is None or start_pct <= TRANSITION_MIN_OFF_PCT:
+        if not self.is_on or start_pct is None or start_pct <= MIN_BRIGHTNESS_PCT:
             return False
 
         steps, interval = self._fade_plan(
-            start_pct, TRANSITION_MIN_OFF_PCT, None, None, transition
+            start_pct, MIN_BRIGHTNESS_PCT, None, None, transition
         )
         self._transition_task = self.hass.async_create_task(
             self._async_run_fade(steps, interval, turn_off_after=True)
@@ -540,7 +544,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 )
                 commands = []
                 if pct is not None:
-                    commands.append(self.device.set_brightness(pct))
+                    commands.append(self.device.set_brightness(_apply_brightness_floor(pct)))
                 if kelvin is not None:
                     commands.append(self.device.set_color_temperature(kelvin))
                 if not commands:

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -266,6 +266,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             await self.async_turn_off(**kwargs)
             return
 
+        # Clamp to the minimum safe brightness floor (device-percent level).
+        if brightness is not None:
+            clamped_pct = max(_to_dlight_brightness(brightness), MIN_BRIGHTNESS_PCT)
+            brightness = math.floor(clamped_pct / 100 * 255)
+
         # The newest command always wins over a fade already in flight.
         await self._async_cancel_transition()
 
@@ -306,16 +311,14 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         if brightness is not None and kelvin is not None:
             commands.append(
                 self.device.apply_scene(
-                    brightness=_apply_brightness_floor(_to_dlight_brightness(brightness)),
+                    brightness=_to_dlight_brightness(brightness),
                     temperature=int(kelvin),
                 )
             )
         else:
             if brightness is not None:
                 commands.append(
-                    self.device.set_brightness(
-                        _apply_brightness_floor(_to_dlight_brightness(brightness))
-                    )
+                    self.device.set_brightness(_to_dlight_brightness(brightness))
                 )
             if kelvin is not None:
                 commands.append(self.device.set_color_temperature(int(kelvin)))
@@ -544,7 +547,8 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 )
                 commands = []
                 if pct is not None:
-                    commands.append(self.device.set_brightness(_apply_brightness_floor(pct)))
+                    pct = _apply_brightness_floor(pct)
+                    commands.append(self.device.set_brightness(pct))
                 if kelvin is not None:
                     commands.append(self.device.set_color_temperature(kelvin))
                 if not commands:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -317,12 +317,13 @@ async def test_light_turn_off_with_transition(
     )
     await hass.async_block_till_done()
 
-    # From 50% in 2 steps: an intermediate dim, then the 1% floor, then off.
+    # From 50% in 2 steps: an intermediate dim, then the MIN_BRIGHTNESS_PCT floor, then off.
+    from custom_components.dlight.const import MIN_BRIGHTNESS_PCT
     brightness_calls = [
         c.args[0] for c in mock_dlight_device.set_brightness.call_args_list
     ]
-    assert brightness_calls[-1] == 1
-    assert all(0 < b < 50 for b in brightness_calls)
+    assert brightness_calls[-1] == MIN_BRIGHTNESS_PCT
+    assert all(0 < b <= 50 for b in brightness_calls)
     mock_dlight_device.turn_off.assert_called_once()
     assert hass.states.get("light.test_light").state == "off"
 
@@ -951,3 +952,44 @@ async def test_physical_control_not_fired_during_transition(
 
     # Cleanup: cancel the fade so the test doesn't block for 20 real seconds.
     await entity._async_cancel_transition()
+
+
+# --- Minimum brightness floor ---
+
+async def test_turn_on_brightness_below_floor_is_clamped(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """turn_on with brightness=1 must send MIN_BRIGHTNESS_PCT to the device."""
+    from custom_components.dlight.const import MIN_BRIGHTNESS_PCT
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "brightness": 1},
+        blocking=True,
+    )
+
+    # brightness=1 on HA scale is ceil(1/255*100)=1% device → clamped to MIN_BRIGHTNESS_PCT
+    mock_dlight_device.set_brightness.assert_called_with(MIN_BRIGHTNESS_PCT)
+
+
+async def test_turn_off_ignores_brightness_floor(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """turn_off must send the power-off command regardless of the floor."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {"entity_id": "light.test_light"}, blocking=True
+    )
+
+    mock_dlight_device.turn_off.assert_called_once()
+    mock_dlight_device.set_brightness.assert_not_called()
+    assert hass.states.get("light.test_light").state == "off"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 
 import pytest
 from unittest.mock import patch
@@ -975,6 +976,9 @@ async def test_turn_on_brightness_below_floor_is_clamped(
 
     # brightness=1 on HA scale is ceil(1/255*100)=1% device → clamped to MIN_BRIGHTNESS_PCT
     mock_dlight_device.set_brightness.assert_called_with(MIN_BRIGHTNESS_PCT)
+    # State reflects the clamped floor: device returns 5% → _to_ha_brightness(5) = ceil(12.75) = 13
+    state = hass.states.get("light.test_light")
+    assert state.attributes.get("brightness") == math.ceil(MIN_BRIGHTNESS_PCT / 100 * 255)
 
 
 async def test_turn_off_ignores_brightness_floor(


### PR DESCRIPTION
## Summary

- Adds `MIN_BRIGHTNESS_PCT = 5` constant to `const.py` (with comment explaining why).
- All `turn_on` brightness values and fade step commands are clamped to `max(pct, MIN_BRIGHTNESS_PCT)` before being sent to the device.
- Fade-to-off sequence uses `MIN_BRIGHTNESS_PCT` as its floor instead of the former magic number `1`.
- `turn_off` is explicitly exempt — switching off always works regardless of the floor.

Closes #33

## Test plan

- [ ] `turn_on(brightness=1)` sends `MIN_BRIGHTNESS_PCT` (5%) to the device
- [ ] `turn_off` sends `turn_off()` with no `set_brightness` call
- [ ] Fade-to-off floor updated to match the new constant
- [ ] All existing tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)