### PR TITLE
fix(binary_sensor): replace rediscovery_triggered with accurate rediscovery_in_progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add missing `discovery_none` translation strings to `strings.json` and all five locale files (`en`, `de`, `fr`, `ga`, `ja`), fixing blank UI when UDP discovery returns zero results (closes #45).
 - Restore separate `FADE_TO_OFF_TARGET_PCT = 1` constant so `_async_start_turn_off_fade` fades to 1% (not 5%), giving full-range step count and proper pacing at low brightness (closes #46).
+- Replace misleading `rediscovery_triggered` binary sensor attribute with `rediscovery_in_progress` backed by a real task-liveness check on the coordinator (closes #47).
 
 ### Added
 - Add structured debug logging across `coordinator.py` (poll start/success/failure, rediscovery), `light.py` (turn-on/off/toggle params, optimistic state, fade step-by-step, poll-guard decisions), and `config_flow.py` (discovery result count, known-lamp self-heal, DHCP step trigger).

--- a/custom_components/dlight/binary_sensor.py
+++ b/custom_components/dlight/binary_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, POLL_INTERVAL, REDISCOVERY_FAILURE_THRESHOLD
+from .const import DOMAIN, POLL_INTERVAL
 from .coordinator import DLightCoordinator
 
 # Read-only view over coordinator data; nothing to serialize.
@@ -79,6 +79,6 @@ class DLightConnectivitySensor(CoordinatorEntity[DLightCoordinator], BinarySenso
         return {
             "consecutive_failures": coord.consecutive_failures,
             "last_successful_poll": coord.last_successful_poll,
-            "rediscovery_triggered": coord.consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD,
+            "rediscovery_in_progress": coord.rediscovery_in_progress,
             "poll_interval_seconds": POLL_INTERVAL,
         }

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -80,6 +80,11 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Return the timestamp of the last successful poll."""
         return self._last_successful_poll
 
+    @property
+    def rediscovery_in_progress(self) -> bool:
+        """Return True while a UDP rediscovery sweep task is actively running."""
+        return self._rediscovery_task is not None and not self._rediscovery_task.done()
+
     @callback
     def _handle_device_state_change(
         self,

--- a/custom_components/dlight/coordinator.py
+++ b/custom_components/dlight/coordinator.py
@@ -226,37 +226,40 @@ class DLightCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._consecutive_failures,
         )
         try:
-            ping_ok = await self.device.ping(timeout=2.0)
-        except Exception:  # noqa: BLE001 — defensively catch any errors in ping
-            ping_ok = False
+            try:
+                ping_ok = await self.device.ping(timeout=2.0)
+            except Exception:  # noqa: BLE001 — defensively catch any errors in ping
+                ping_ok = False
 
-        if ping_ok:
-            _LOGGER.debug(
-                "dLight %s is reachable on current IP %s via ping; skipping UDP sweep",
-                self.device.id,
-                self.device.ip,
-            )
-            return
+            if ping_ok:
+                _LOGGER.debug(
+                    "dLight %s is reachable on current IP %s via ping; skipping UDP sweep",
+                    self.device.id,
+                    self.device.ip,
+                )
+                return
 
-        try:
-            async for found in discover_devices_stream(timeout=REDISCOVERY_DURATION):
-                if found.get("deviceId") != self.device.id:
-                    continue
-                new_ip = found.get("ip_address")
-                if new_ip and new_ip != self.device.ip:
-                    _LOGGER.info(
-                        "dLight %s found at new address %s (was %s); updating entry",
-                        self.device.id,
-                        new_ip,
-                        self.device.ip,
-                    )
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry,
-                        data={**self.config_entry.data, CONF_IP_ADDRESS: new_ip},
-                    )
-                    self.hass.config_entries.async_schedule_reload(
-                        self.config_entry.entry_id
-                    )
-                break
-        except Exception:  # noqa: BLE001 — best-effort recovery, never raise
-            _LOGGER.debug("dLight rediscovery sweep failed", exc_info=True)
+            try:
+                async for found in discover_devices_stream(timeout=REDISCOVERY_DURATION):
+                    if found.get("deviceId") != self.device.id:
+                        continue
+                    new_ip = found.get("ip_address")
+                    if new_ip and new_ip != self.device.ip:
+                        _LOGGER.info(
+                            "dLight %s found at new address %s (was %s); updating entry",
+                            self.device.id,
+                            new_ip,
+                            self.device.ip,
+                        )
+                        self.hass.config_entries.async_update_entry(
+                            self.config_entry,
+                            data={**self.config_entry.data, CONF_IP_ADDRESS: new_ip},
+                        )
+                        self.hass.config_entries.async_schedule_reload(
+                            self.config_entry.entry_id
+                        )
+                    break
+            except Exception:  # noqa: BLE001 — best-effort recovery, never raise
+                _LOGGER.debug("dLight rediscovery sweep failed", exc_info=True)
+        finally:
+            self.async_update_listeners()

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -58,7 +58,7 @@ The **Connectivity** binary sensor exposes health metrics in its state attribute
 |---|---|
 | `consecutive_failures` | How many polls have failed in a row. Resets to `0` on success. |
 | `last_successful_poll` | Timestamp of the last poll that got a response. `None` until the first success. |
-| `rediscovery_triggered` | `true` after 3 consecutive failures — a UDP rediscovery sweep is in flight. |
+| `rediscovery_in_progress` | `true` while a UDP rediscovery sweep task is actively running. |
 | `poll_interval_seconds` | How frequently the lamp is polled (default 30 s). |
 
 A lamp that's been offline for 3 polls (~90 s) automatically triggers a rediscovery sweep. If it answers from a new IP, the entry is updated and the coordinator resumes without any manual steps.

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -61,7 +61,7 @@ async def test_connectivity_sensor_health_attributes_degraded(
     hass, mock_dlight_device, mock_config_entry
 ):
     """consecutive_failures increments on poll errors; rediscovery_in_progress reflects task state."""
-    from unittest.mock import patch as _patch
+    from unittest.mock import AsyncMock, patch as _patch
 
     await setup_integration(hass, mock_config_entry)
     entity_id = er.async_get(hass).async_get_entity_id(
@@ -72,7 +72,7 @@ async def test_connectivity_sensor_health_attributes_degraded(
 
     mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
     # Suppress rediscovery so the test doesn't trigger an entry reload.
-    with _patch.object(coordinator, "_async_attempt_rediscovery", return_value=None):
+    with _patch.object(coordinator, "_async_attempt_rediscovery", new_callable=AsyncMock):
         for _ in range(REDISCOVERY_FAILURE_THRESHOLD):
             await coordinator.async_refresh()
             await hass.async_block_till_done()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -53,14 +53,14 @@ async def test_connectivity_sensor_health_attributes_healthy(
 
     assert attrs["consecutive_failures"] == 0
     assert attrs["last_successful_poll"] is not None  # set by setup poll
-    assert attrs["rediscovery_triggered"] is False
+    assert attrs["rediscovery_in_progress"] is False
     assert attrs["poll_interval_seconds"] == POLL_INTERVAL
 
 
 async def test_connectivity_sensor_health_attributes_degraded(
     hass, mock_dlight_device, mock_config_entry
 ):
-    """consecutive_failures increments on poll errors; rediscovery_triggered flips at threshold."""
+    """consecutive_failures increments on poll errors; rediscovery_in_progress reflects task state."""
     from unittest.mock import patch as _patch
 
     await setup_integration(hass, mock_config_entry)
@@ -82,16 +82,17 @@ async def test_connectivity_sensor_health_attributes_degraded(
     assert coordinator.consecutive_failures == REDISCOVERY_FAILURE_THRESHOLD
     assert coordinator.last_successful_poll is not None
     assert coordinator.last_successful_poll == last_good_poll
-    assert coordinator.consecutive_failures >= REDISCOVERY_FAILURE_THRESHOLD  # rediscovery_triggered
+    # No real rediscovery task was spawned (patched out), so rediscovery_in_progress is False.
+    assert coordinator.rediscovery_in_progress is False
 
-    # Recovery: failures reset, timestamp refreshes, rediscovery_triggered clears.
+    # Recovery: failures reset, timestamp refreshes, rediscovery_in_progress stays False.
     mock_dlight_device.get_state.side_effect = None
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
     attrs = hass.states.get(entity_id).attributes
     assert attrs["consecutive_failures"] == 0
-    assert attrs["rediscovery_triggered"] is False
+    assert attrs["rediscovery_in_progress"] is False
     assert attrs["last_successful_poll"] != last_good_poll
 
 


### PR DESCRIPTION
## Summary

- Replaces the misleading `rediscovery_triggered` attribute (which stayed `True` for all poll failures ≥ threshold, including between sweeps) with `rediscovery_in_progress` backed by a task-liveness check (`_rediscovery_task is not None and not done()`) on the coordinator.
- Adds `DLightCoordinator.rediscovery_in_progress` property; updates `binary_sensor.py`, tests, and troubleshooting docs to use the new name.

Closes #47

## Test plan

- [ ] `test_connectivity_sensor_health_attributes_healthy` — `rediscovery_in_progress` is `False` on a healthy coordinator.
- [ ] `test_connectivity_sensor_health_attributes_degraded` — confirms `rediscovery_in_progress` is `False` when the rediscovery task is patched out (no real task running).
- [ ] All existing tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)