### PR TITLE
fix(light): use _to_ha_brightness for floor clamp and HA-scale guard comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore separate `FADE_TO_OFF_TARGET_PCT = 1` constant so `_async_start_turn_off_fade` fades to 1% (not 5%), giving full-range step count and proper pacing at low brightness (closes #46).
 - Replace misleading `rediscovery_triggered` binary sensor attribute with `rediscovery_in_progress` backed by a real task-liveness check on the coordinator (closes #47).
 - Add `identify_in_progress` flag to coordinator; set in `button.py` `async_press` via try/finally and checked in `light.py` `_handle_coordinator_update` to suppress spurious `dlight_physical_control` events when a coordinator poll lands mid-flash (closes #51).
+- Replace `math.floor` with `_to_ha_brightness` when clamping `_optimistic_brightness` in `async_turn_on`, and use `clamped_pct` directly in device commands to avoid a lossy HA→device→HA round-trip; fix the rapid-fire guard comparison to compare in HA scale so clamped-floor polls are correctly accepted (closes #48).
 
 ### Added
 - Add structured debug logging across `coordinator.py` (poll start/success/failure, rediscovery), `light.py` (turn-on/off/toggle params, optimistic state, fade step-by-step, poll-guard decisions), and `config_flow.py` (discovery result count, known-lamp self-heal, DHCP step trigger).

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -280,7 +280,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         if (
             transition is not None
             and transition > 0
-            and self._async_start_turn_on_fade(brightness, kelvin, transition)
+            and self._async_start_turn_on_fade(clamped_pct, kelvin, transition)
         ):
             return
 
@@ -441,9 +441,12 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
     @callback
     def _async_start_turn_on_fade(
-        self, brightness: int | None, kelvin: int | None, transition: float
+        self, target_pct: int | None, kelvin: int | None, transition: float
     ) -> bool:
         """Schedule a fade toward the requested turn_on target.
+
+        target_pct is in device scale (0-100); callers should pass clamped_pct
+        directly to avoid a lossy HA-scale → device-scale → HA-scale round-trip.
 
         Returns False when fading is impossible (the lamp's current state is
         unknown, or nothing would actually change) so the caller falls back
@@ -455,8 +458,8 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
 
         current_pct = self._current_pct()
 
-        if brightness is not None:
-            end_pct = _to_dlight_brightness(brightness)
+        if target_pct is not None:
+            end_pct = target_pct
         elif not is_on:
             # Bare turn_on from off: fade in to the last known level.
             end_pct = current_pct or 100
@@ -681,7 +684,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             if self._optimistic_on != polled_on:
                 matches = False
             if self._optimistic_brightness is not None:
-                if _to_ha_brightness(polled_brightness) != self._optimistic_brightness:
+                if polled_brightness is None or _to_ha_brightness(polled_brightness) != self._optimistic_brightness:
                     matches = False
             if (
                 self._optimistic_kelvin is not None

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -267,9 +267,12 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             return
 
         # Clamp to the minimum safe brightness floor (device-percent level).
+        # clamped_pct is used directly in device commands to avoid a lossy
+        # HA-scale → device-percent → HA-scale round-trip.
+        clamped_pct: int | None = None
         if brightness is not None:
             clamped_pct = max(_to_dlight_brightness(brightness), MIN_BRIGHTNESS_PCT)
-            brightness = math.floor(clamped_pct / 100 * 255)
+            brightness = _to_ha_brightness(clamped_pct)
 
         # The newest command always wins over a fade already in flight.
         await self._async_cancel_transition()
@@ -308,17 +311,17 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         # When both brightness and temperature are set atomically, apply_scene
         # reduces two TCP commands to one and rolls back both on failure.
         commands = []
-        if brightness is not None and kelvin is not None:
+        if clamped_pct is not None and kelvin is not None:
             commands.append(
                 self.device.apply_scene(
-                    brightness=_to_dlight_brightness(brightness),
+                    brightness=clamped_pct,
                     temperature=int(kelvin),
                 )
             )
         else:
-            if brightness is not None:
+            if clamped_pct is not None:
                 commands.append(
-                    self.device.set_brightness(_to_dlight_brightness(brightness))
+                    self.device.set_brightness(clamped_pct)
                 )
             if kelvin is not None:
                 commands.append(self.device.set_color_temperature(int(kelvin)))
@@ -678,10 +681,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             if self._optimistic_on != polled_on:
                 matches = False
             if self._optimistic_brightness is not None:
-                if (
-                    _to_dlight_brightness(self._optimistic_brightness)
-                    != polled_brightness
-                ):
+                if _to_ha_brightness(polled_brightness) != self._optimistic_brightness:
                     matches = False
             if (
                 self._optimistic_kelvin is not None


### PR DESCRIPTION
## Summary
- Replace `math.floor(clamped_pct / 100 * 255)` with `_to_ha_brightness(clamped_pct)` in `async_turn_on` so `_optimistic_brightness` is consistent with the value a confirmed poll produces for the same device state — eliminates the 1-unit snap-on-confirm (12→13 at 5% floor)
- Use `clamped_pct` directly in device commands (`set_brightness`, `apply_scene`) to avoid the lossy `HA→device→HA` round-trip that caused `set_brightness(6)` instead of `set_brightness(5)` after switching to `ceil`
- Fix the rapid-fire guard comparison to compare in HA scale (`_to_ha_brightness(polled_brightness) == _optimistic_brightness`) so a poll confirming the floor-clamped value is correctly accepted, not rejected as stale

## Test plan
- [ ] Existing `test_turn_on_brightness_below_floor_is_clamped` now asserts `set_brightness(5)` (correct device call) and `brightness == 13` (consistent HA scale) — both pass
- [ ] Full suite: `python -m pytest` — 87 passed

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)