### PR TITLE
fix(light): anchor fade-up start_pct at MIN_BRIGHTNESS_PCT to prevent stutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace misleading `rediscovery_triggered` binary sensor attribute with `rediscovery_in_progress` backed by a real task-liveness check on the coordinator (closes #47).
 - Add `identify_in_progress` flag to coordinator; set in `button.py` `async_press` via try/finally and checked in `light.py` `_handle_coordinator_update` to suppress spurious `dlight_physical_control` events when a coordinator poll lands mid-flash (closes #51).
 - Replace `math.floor` with `_to_ha_brightness` when clamping `_optimistic_brightness` in `async_turn_on`, and use `clamped_pct` directly in device commands to avoid a lossy HA→device→HA round-trip; fix the rapid-fire guard comparison to compare in HA scale so clamped-floor polls are correctly accepted (closes #48).
+- Clamp `start_pct` to `MIN_BRIGHTNESS_PCT` before computing the interpolation plan in `_async_start_turn_on_fade`, eliminating the visual stutter when fading up from a sub-floor brightness set by an external client (closes #49).
 
 ### Added
 - Add structured debug logging across `coordinator.py` (poll start/success/failure, rediscovery), `light.py` (turn-on/off/toggle params, optimistic state, fade step-by-step, poll-guard decisions), and `config_flow.py` (discovery result count, known-lamp self-heal, DHCP step trigger).

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -466,6 +466,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         else:
             end_pct = None  # already on, brightness untouched
         start_pct = current_pct if is_on else 0
+        # If the lamp is externally set below the floor (e.g. via the dLight
+        # app), anchor the interpolation at MIN_BRIGHTNESS_PCT so the first
+        # fade step doesn't jump visually from sub-floor to the floor value.
+        if start_pct is not None and start_pct > 0:
+            start_pct = max(start_pct, MIN_BRIGHTNESS_PCT)
 
         end_kelvin = int(kelvin) if kelvin is not None else None
         start_kelvin = self.color_temp_kelvin

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1055,3 +1055,52 @@ async def test_turn_off_fade_from_low_brightness_uses_fade_to_off_target(
     # Power-off must follow the fade.
     mock_dlight_device.turn_off.assert_called_once()
     assert hass.states.get("light.test_light").state == "off"
+
+
+async def test_fade_up_from_subfloor_brightness_anchors_start(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Fading up from below MIN_BRIGHTNESS_PCT must not stutter on the first step.
+
+    Regression for #49: _async_start_turn_on_fade must clamp start_pct to
+    MIN_BRIGHTNESS_PCT before computing the fade plan.  Without the fix, early
+    interpolated steps (e.g. 3%, 4%) are all floored to 5% in _async_run_fade,
+    producing a burst of identical set_brightness(5) calls before the smooth fade
+    begins.
+    """
+    from custom_components.dlight.const import MIN_BRIGHTNESS_PCT
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    # Simulate the lamp being set to 2% by an external client (below the floor).
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 2,
+        "color": {"temperature": 4000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Fade to 7% over 1s (2 steps): with start anchored at 5%, first step
+    # interpolates to 6%; without the fix it would jump to 5% (the floor).
+    # HA brightness 17 -> _to_dlight_brightness(17) = ceil(6.67) = 7 -> target_pct=7.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "brightness": 17, "transition": 1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    brightness_calls = [c.args[0] for c in mock_dlight_device.set_brightness.call_args_list]
+    # With fix: start is anchored to 5, fade plan is [6, 7] — no stutter.
+    # Without fix: first step would be set_brightness(5) (the floor value).
+    assert brightness_calls, "No set_brightness calls — fade did not run"
+    assert brightness_calls[0] > MIN_BRIGHTNESS_PCT, (
+        f"Fade stuttered to floor on first step: calls={brightness_calls}"
+    )


### PR DESCRIPTION
## Summary
- Clamp `start_pct` to `MIN_BRIGHTNESS_PCT` before computing the interpolation plan in `_async_start_turn_on_fade`
- Without this fix, a lamp externally set below 5% causes early interpolated steps (3%, 4%) to all get floored to 5% in `_async_run_fade`, producing a burst of `set_brightness(5)` calls before the smooth fade begins — a visible jump
- With the fix, the interpolation starts from 5% so every step is a meaningful increment toward the target

## Test plan
- [ ] `test_fade_up_from_subfloor_brightness_anchors_start`: sets lamp at 2%, fades to 7%, asserts first `set_brightness` call is `> MIN_BRIGHTNESS_PCT` (i.e. 6, not 5)
- [ ] Full suite: `python -m pytest` — 88 passed

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)