### PR TITLE
fix(config_flow): async_step_retry must not trigger IP self-healing (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `identify_in_progress` flag to coordinator; set in `button.py` `async_press` via try/finally and checked in `light.py` `_handle_coordinator_update` to suppress spurious `dlight_physical_control` events when a coordinator poll lands mid-flash (closes #51).
 - Replace `math.floor` with `_to_ha_brightness` when clamping `_optimistic_brightness` in `async_turn_on`, and use `clamped_pct` directly in device commands to avoid a lossy HA→device→HA round-trip; fix the rapid-fire guard comparison to compare in HA scale so clamped-floor polls are correctly accepted (closes #48).
 - Clamp `start_pct` to `MIN_BRIGHTNESS_PCT` before computing the interpolation plan in `_async_start_turn_on_fade`, eliminating the visual stutter when fading up from a sub-floor brightness set by an external client (closes #49).
+- Extract `_filter_new_devices` and `_heal_known_lamps` helpers in `config_flow.py`; `async_step_retry` now calls only `_filter_new_devices`, preventing a silent coordinator reload when a known lamp reappears on a new IP during a user-initiated retry scan (closes #50).
 
 ### Added
 - Add structured debug logging across `coordinator.py` (poll start/success/failure, rediscovery), `light.py` (turn-on/off/toggle params, optimistic state, fade step-by-step, poll-guard decisions), and `config_flow.py` (discovery result count, known-lamp self-heal, DHCP step trigger).

--- a/custom_components/dlight/config_flow.py
+++ b/custom_components/dlight/config_flow.py
@@ -118,16 +118,28 @@ class DLightConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             devices = []
 
         _LOGGER.debug("dLight discovery found %d device(s)", len(devices))
-        # Split discoveries: unknown lamps go to the pick-list; known lamps
-        # (matched by unique_id) get their stored IP self-healed if the
-        # router handed them a new address since setup.
+        self._discovered = self._filter_new_devices(devices)
+        self._heal_known_lamps(devices)
+
+        if self._discovered:
+            return await self.async_step_discovery()
+        return await self.async_step_discovery_none()
+
+    def _filter_new_devices(self, devices: list[dict]) -> dict[str, dict]:
+        """Return only devices not already registered as config entries."""
+        known_ids = {entry.unique_id for entry in self._async_current_entries()}
+        return {
+            d["deviceId"]: d
+            for d in devices
+            if f"dlight_{d['deviceId']}" not in known_ids
+        }
+
+    def _heal_known_lamps(self, devices: list[dict]) -> None:
+        """Update the stored IP for any known lamp found on a new address."""
         known = {entry.unique_id: entry for entry in self._async_current_entries()}
-        self._discovered = {}
         for found in devices:
             entry = known.get(f"dlight_{found['deviceId']}")
-            if entry is None:
-                self._discovered[found["deviceId"]] = found
-            elif entry.data.get(CONF_IP_ADDRESS) != found["ip_address"]:
+            if entry is not None and entry.data.get(CONF_IP_ADDRESS) != found["ip_address"]:
                 _LOGGER.info(
                     "dLight %s moved to %s; updating its config entry",
                     found["deviceId"],
@@ -138,10 +150,6 @@ class DLightConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 # Reload so the running coordinator targets the new address.
                 self.hass.config_entries.async_schedule_reload(entry.entry_id)
-
-        if self._discovered:
-            return await self.async_step_discovery()
-        return await self.async_step_discovery_none()
 
     async def async_step_discovery_none(
         self, user_input: dict[str, Any] | None = None
@@ -155,8 +163,24 @@ class DLightConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_retry(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Retry discovery from the discovery_none menu."""
-        return await self.async_step_user()
+        """Retry discovery without triggering IP self-healing for existing lamps.
+
+        The user clicked "Try again" to scan for *new* lamps, not to heal
+        existing entries — silently reloading a coordinator mid-use is an
+        unexpected side effect in this context.
+        """
+        try:
+            devices = await discover_devices(discovery_duration=DISCOVERY_DURATION)
+        except Exception:  # noqa: BLE001 — discovery is best-effort, never fatal
+            _LOGGER.exception("dLight discovery failed during retry; falling back to discovery_none")
+            devices = []
+
+        _LOGGER.debug("dLight retry discovery found %d device(s)", len(devices))
+        self._discovered = self._filter_new_devices(devices)
+
+        if self._discovered:
+            return await self.async_step_discovery()
+        return await self.async_step_discovery_none()
 
     async def async_step_discovery(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/dlight/config_flow.py
+++ b/custom_components/dlight/config_flow.py
@@ -127,11 +127,11 @@ class DLightConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _filter_new_devices(self, devices: list[dict]) -> dict[str, dict]:
         """Return only devices not already registered as config entries."""
-        known_ids = {entry.unique_id for entry in self._async_current_entries()}
+        known_ids = {entry.unique_id for entry in self._async_current_entries() if entry.unique_id}
         return {
-            d["deviceId"]: d
+            device_id: d
             for d in devices
-            if f"dlight_{d['deviceId']}" not in known_ids
+            if (device_id := d.get("deviceId")) and f"dlight_{device_id}" not in known_ids
         }
 
     def _heal_known_lamps(self, devices: list[dict]) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -169,6 +169,52 @@ async def test_discovery_heals_changed_ip(hass):
     # ...but its stored IP has been refreshed
     assert entry.data[CONF_IP_ADDRESS] == "192.168.1.99"
 
+async def test_retry_does_not_heal_known_lamp_ip(hass):
+    """Regression for #50: async_step_retry must NOT update entries for known lamps.
+
+    When a user clicks "Try again" from discovery_none, the intent is to scan
+    for *new* lamps. If a known lamp appears on a new IP during that scan it
+    must be silently ignored — self-healing is reserved for the initial user
+    step so that an unexpected coordinator reload cannot fire mid-use.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "192.168.1.10", CONF_DEVICE_ID: "known_id"},
+        title="Known Lamp",
+        unique_id="dlight_known_id",
+    )
+    entry.add_to_hass(hass)
+
+    # First init: no devices found → discovery_none
+    with patch("custom_components.dlight.config_flow.discover_devices", return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["step_id"] == "discovery_none"
+
+    # Retry: known lamp appears on a new IP
+    mock_devices = [
+        {"deviceId": "known_id", "ip_address": "192.168.1.99", "deviceModel": "dLight"}
+    ]
+    with patch("custom_components.dlight.config_flow.discover_devices", return_value=mock_devices), \
+         patch.object(hass.config_entries, "async_update_entry") as mock_update, \
+         patch.object(hass.config_entries, "async_schedule_reload") as mock_reload:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"next_step_id": "retry"},
+        )
+        await hass.async_block_till_done()
+
+    # The retry must not have healed the entry
+    mock_update.assert_not_called()
+    mock_reload.assert_not_called()
+    # Stored IP unchanged
+    assert entry.data[CONF_IP_ADDRESS] == "192.168.1.10"
+    # Known lamp was filtered out → still no new devices → discovery_none again
+    assert result["type"] == data_entry_flow.FlowResultType.MENU
+    assert result["step_id"] == "discovery_none"
+
+
 async def test_manual_readd_updates_ip(hass):
     """Manually re-adding a configured lamp aborts but heals its stored IP."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Summary

- Extract `_filter_new_devices` and `_heal_known_lamps` helpers from `async_step_user`
- `async_step_retry` now calls only `_filter_new_devices` — when the user clicks "Try again", known lamps found on a new IP are silently ignored rather than triggering a coordinator reload mid-use
- Regression test added: `test_retry_does_not_heal_known_lamp_ip` asserts `async_update_entry` and `async_schedule_reload` are never called from the retry path

## Test plan

- [x] `python -m pytest` — 89 tests pass
- [x] `test_retry_does_not_heal_known_lamp_ip` confirms retry path skips healing
- [x] `test_discovery_heals_changed_ip` confirms initial user-step healing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)