### PR TITLE
fix(light): log all exceptions in _send() batch before re-raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Redact `macAddress` in diagnostics download by adding it to `TO_REDACT` and passing `coordinator.info` through `async_redact_data` (closes #59).
+- Log all exceptions from a failed `_send()` batch before re-raising the first, so compound device failures (e.g. simultaneous `turn_on` + `set_brightness` errors) are fully visible in the HA log (closes #60).
 
 ## [2.3.2] - 2026-06-14
 

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -433,9 +433,17 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         """
         async with self.coordinator.command_lock:
             results = await asyncio.gather(*commands, return_exceptions=True)
-        for result in results:
-            if isinstance(result, Exception):
-                raise result
+        errors = [r for r in results if isinstance(r, Exception)]
+        if len(errors) > 1:
+            for exc in errors[1:]:
+                _LOGGER.warning(
+                    "dLight %s: additional command failure in batch: %s",
+                    self.device.id,
+                    exc,
+                    exc_info=exc,
+                )
+        if errors:
+            raise errors[0]
 
     # --- Emulated transitions ---
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2,7 +2,7 @@ import asyncio
 import math
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
 from custom_components.dlight.const import DOMAIN, EVENT_PHYSICAL_CONTROL
@@ -1103,4 +1103,50 @@ async def test_fade_up_from_subfloor_brightness_anchors_start(
     assert brightness_calls, "No set_brightness calls — fade did not run"
     assert brightness_calls[0] > MIN_BRIGHTNESS_PCT, (
         f"Fade stuttered to floor on first step: calls={brightness_calls}"
+    )
+
+
+async def test_send_logs_all_exceptions_in_batch(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """When two commands fail simultaneously, all failures appear in the log.
+
+    turn_on(brightness=X) while the lamp is off issues two concurrent commands:
+    turn_on() and set_brightness(). If both fail, only the first is re-raised
+    as a HomeAssistantError but the second must appear in the WARNING log.
+    """
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Put the lamp in the off state so turn_on() is prepended to the batch.
+    mock_dlight_device.get_state.return_value = {
+        "on": False,
+        "brightness": 50,
+        "color": {"temperature": 4000},
+    }
+    coordinator = mock_config_entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    err1 = OSError("network error on turn_on")
+    err2 = OSError("network error on set_brightness")
+
+    mock_dlight_device.turn_on.side_effect = err1
+    mock_dlight_device.set_brightness.side_effect = err2
+
+    with pytest.raises(Exception), \
+         patch("custom_components.dlight.light._LOGGER") as mock_logger:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            "turn_on",
+            {"entity_id": "light.test_light", "brightness": 128},
+            blocking=True,
+        )
+
+    # The second (additional) exception must be logged as a warning
+    warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+    assert any("additional command failure" in c for c in warning_calls), (
+        f"Second exception was not logged. warning calls: {warning_calls}"
     )


### PR DESCRIPTION
## Summary

- Collect all exceptions from `asyncio.gather(return_exceptions=True)` in `_send()` and log each secondary failure at `WARNING` before re-raising the first, so compound device failures (e.g. simultaneous `turn_on` + `set_brightness` errors) are fully visible in the HA log rather than silently discarded.

Closes #60

## Test plan

- [ ] `test_send_logs_all_exceptions_in_batch`: turns lamp off, injects failures into both `turn_on()` and `set_brightness()`, then asserts the secondary exception appears in `_LOGGER.warning` calls.
- [ ] Happy path unaffected — single-command and zero-exception batches continue to behave identically.
- [ ] All existing tests pass (`python -m pytest`) — 90 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)