### PR TITLE
fix(light): suppress spurious physical_control event on failed fade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Redact `macAddress` in diagnostics download by adding it to `TO_REDACT` and passing `coordinator.info` through `async_redact_data` (closes #59).
 - Log all exceptions from a failed `_send()` batch before re-raising the first, so compound device failures (e.g. simultaneous `turn_on` + `set_brightness` errors) are fully visible in the HA log (closes #60).
+- Suppress spurious `dlight_physical_control` event after a failed emulated transition by stamping `_last_command_time` at fade start and short-circuiting `_handle_coordinator_update` via a `_fade_failed` guard (closes #61).
 
 ## [2.3.2] - 2026-06-14
 

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -186,6 +186,11 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         # physical changes between polls. None until the first poll is accepted.
         self._last_confirmed_data: dict | None = None
 
+        # Set to True when an emulated fade fails mid-run; cleared by the next
+        # _handle_coordinator_update call to suppress a spurious physical_control
+        # event that would otherwise fire because optimistic state was just cleared.
+        self._fade_failed: bool = False
+
         # The registry card is built once: coordinator.info is static
         # (fetched a single time at setup, see DLightCoordinator).
         device_info = DeviceInfo(
@@ -565,6 +570,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             interval,
             turn_off_after,
         )
+        self._last_command_time = time.monotonic()
         try:
             for index, (pct, kelvin) in enumerate(steps):
                 if index:
@@ -609,6 +615,7 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
                 self.device.id,
                 exc_info=True,
             )
+            self._fade_failed = True
             self._clear_optimistic_state()
             self.async_write_ha_state()
 
@@ -676,6 +683,16 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
             # poisoned with a transient state; otherwise the post-flash restore
             # poll would look like an external change and fire a spurious event.
             _LOGGER.debug("dLight %s: poll rejected (identify in progress)", self.device.id)
+            return
+        if self._fade_failed:
+            # A fade that failed mid-run already cleared optimistic state, so
+            # within_hold would be False and a spurious physical_control event
+            # would fire.  Accept the poll silently instead.
+            _LOGGER.debug("dLight %s: poll accepted after failed fade", self.device.id)
+            self._fade_failed = False
+            self._last_confirmed_data = self.coordinator.data
+            self._clear_optimistic_state()
+            super()._handle_coordinator_update()
             return
 
         within_hold = (

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -955,6 +955,42 @@ async def test_physical_control_not_fired_during_transition(
     await entity._async_cancel_transition()
 
 
+async def test_failed_fade_does_not_fire_physical_control(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """A failed emulated transition must not fire a dlight_physical_control event."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    events = []
+    hass.bus.async_listen(EVENT_PHYSICAL_CONTROL, lambda e: events.append(e))
+
+    # Inject a failure so the fade fails on the first step.
+    mock_dlight_device.set_brightness.side_effect = OSError("connection reset mid-fade")
+
+    # Start a minimal single-step fade (transition=0.5s → 1 step, no inter-step sleep).
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "brightness": 255, "transition": 0.5},
+        blocking=True,
+    )
+    # Let the background fade task run and reach the exception handler.
+    await hass.async_block_till_done()
+
+    # Simulate the coordinator polling the lamp; the polled state is unchanged.
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert events == [], (
+        f"Spurious physical_control event fired after failed fade: {events}"
+    )
+
+
 # --- Minimum brightness floor ---
 
 async def test_turn_on_brightness_below_floor_is_clamped(


### PR DESCRIPTION
## Summary

- Stamp `_last_command_time` at the start of `_async_run_fade` so the guard window is open from fade start, not just from the last direct command.
- Add a `_fade_failed` boolean flag set in the exception handler; `_handle_coordinator_update` checks this flag to accept the post-failure poll silently (updating state without firing a `dlight_physical_control` event), then resets the flag.

Closes #61

## Test plan

- [ ] `test_failed_fade_does_not_fire_physical_control`: injects an `OSError` into `set_brightness` during a single-step fade, runs the background task to completion, triggers a coordinator refresh, and asserts `events == []`.
- [ ] Successful and cancelled fades are unaffected — all 91 existing tests pass (`python -m pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)