### PR TITLE
dx(ci): add 80% coverage gate to pytest job (closes #62)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --cov=custom_components/dlight --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+          pytest --cov=custom_components/dlight --cov-report=term-missing --cov-report=xml --cov-fail-under=80 --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov (aggregate)
         uses: codecov/codecov-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add `--cov-fail-under=80` coverage gate and `--cov-report=term-missing` summary to the CI pytest job; PRs that drop overall coverage below 80% now fail with a clear per-module report (closes #62).
+
 ### Fixed
 - Redact `macAddress` in diagnostics download by adding it to `TO_REDACT` and passing `coordinator.info` through `async_redact_data` (closes #59).
 - Log all exceptions from a failed `_send()` batch before re-raising the first, so compound device failures (e.g. simultaneous `turn_on` + `set_brightness` errors) are fully visible in the HA log (closes #60).


### PR DESCRIPTION
Closes #62

## Summary
- Adds `--cov-fail-under=80` to the CI `pytest` command so PRs that drop overall coverage below 80% fail with an explicit exit code and message.
- Adds `--cov-report=term-missing` so the CI log prints a per-module breakdown (including uncovered lines) for easy diagnosis.
- `pytest-cov` was already present in `requirements.txt`; no dependency change needed.

## Testing
- Current overall coverage is 92% (well above the 80% gate).
- Verified locally: `python -m pytest --cov=custom_components/dlight --cov-fail-under=80` exits 0.
- CI will enforce the gate on every future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)