### PR TITLE
feat(sensor): add brightness and color temperature diagnostic sensors (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `sensor` platform with two diagnostic entities per lamp: **Brightness** (%, unique id `dlight_{id}_brightness`) and **Color Temperature** (K, unique id `dlight_{id}_color_temp`), both backed by the existing coordinator poll with no extra network traffic (closes #64).
+
 ### Changed
 - Add `--cov-fail-under=80` coverage gate and `--cov-report=term-missing` summary to the CI pytest job; PRs that drop overall coverage below 80% now fail with a clear per-module report (closes #62).
 

--- a/custom_components/dlight/const.py
+++ b/custom_components/dlight/const.py
@@ -4,7 +4,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "dlight"
 EVENT_PHYSICAL_CONTROL = "dlight_physical_control"
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.EVENT, Platform.LIGHT]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.EVENT, Platform.LIGHT, Platform.SENSOR]
 
 # Extra config-entry key (the IP address uses HA's standard CONF_IP_ADDRESS).
 CONF_DEVICE_ID = "device_id"

--- a/custom_components/dlight/sensor.py
+++ b/custom_components/dlight/sensor.py
@@ -1,0 +1,96 @@
+"""Sensor platform for dLight: brightness (%) and color temperature (K).
+
+Both sensors are backed by the shared coordinator — no extra polling.
+They go unavailable when the coordinator has no data (lamp offline).
+"""
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import DLightCoordinator
+
+PARALLEL_UPDATES = 0
+
+_UNIT_KELVIN = "K"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry[DLightCoordinator],
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add brightness and color-temperature sensors for an initialized lamp."""
+    coordinator = entry.runtime_data
+    async_add_entities([
+        DLightBrightnessSensor(coordinator, entry),
+        DLightColorTempSensor(coordinator, entry),
+    ])
+
+
+class _DLightSensorBase(CoordinatorEntity[DLightCoordinator], SensorEntity):
+    """Shared base for both dLight sensor entities."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: DLightCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            name=entry.title or f"dLight {device.id}",
+        )
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+
+class DLightBrightnessSensor(_DLightSensorBase):
+    """Reports lamp brightness as a percentage (0–100)."""
+
+    _attr_translation_key = "brightness"
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, coordinator: DLightCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"dlight_{coordinator.device.id}_brightness"
+
+    @property
+    def native_value(self) -> int | None:
+        data = self.coordinator.data
+        if not data:
+            return None
+        return data.get("brightness")
+
+
+class DLightColorTempSensor(_DLightSensorBase):
+    """Reports lamp color temperature in Kelvin."""
+
+    _attr_translation_key = "color_temp"
+    _attr_native_unit_of_measurement = _UNIT_KELVIN
+
+    def __init__(self, coordinator: DLightCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"dlight_{coordinator.device.id}_color_temp"
+
+    @property
+    def native_value(self) -> int | None:
+        data = self.coordinator.data
+        if not data:
+            return None
+        color = data.get("color")
+        if not isinstance(color, dict):
+            return None
+        return color.get("temperature")

--- a/custom_components/dlight/sensor.py
+++ b/custom_components/dlight/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,8 +20,6 @@ from .const import DOMAIN
 from .coordinator import DLightCoordinator
 
 PARALLEL_UPDATES = 0
-
-_UNIT_KELVIN = "K"
 
 
 async def async_setup_entry(

--- a/custom_components/dlight/sensor.py
+++ b/custom_components/dlight/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/dlight/sensor.py
+++ b/custom_components/dlight/sensor.py
@@ -79,7 +79,7 @@ class DLightColorTempSensor(_DLightSensorBase):
     """Reports lamp color temperature in Kelvin."""
 
     _attr_translation_key = "color_temp"
-    _attr_native_unit_of_measurement = _UNIT_KELVIN
+    _attr_native_unit_of_measurement = UnitOfTemperature.KELVIN
 
     def __init__(self, coordinator: DLightCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator, entry)

--- a/custom_components/dlight/strings.json
+++ b/custom_components/dlight/strings.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "Brightness"
+            },
+            "color_temp": {
+                "name": "Color temperature"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "Physical control",

--- a/custom_components/dlight/translations/de.json
+++ b/custom_components/dlight/translations/de.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "Helligkeit"
+            },
+            "color_temp": {
+                "name": "Farbtemperatur"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "Physische Steuerung",

--- a/custom_components/dlight/translations/en.json
+++ b/custom_components/dlight/translations/en.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "Brightness"
+            },
+            "color_temp": {
+                "name": "Color temperature"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "Physical control",

--- a/custom_components/dlight/translations/fr.json
+++ b/custom_components/dlight/translations/fr.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "Luminosité"
+            },
+            "color_temp": {
+                "name": "Température de couleur"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "Commande physique",

--- a/custom_components/dlight/translations/ga.json
+++ b/custom_components/dlight/translations/ga.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "Gile"
+            },
+            "color_temp": {
+                "name": "Teocht datha"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "Rialú fisiciúil",

--- a/custom_components/dlight/translations/ja.json
+++ b/custom_components/dlight/translations/ja.json
@@ -54,6 +54,14 @@
         }
     },
     "entity": {
+        "sensor": {
+            "brightness": {
+                "name": "輝度"
+            },
+            "color_temp": {
+                "name": "色温度"
+            }
+        },
         "event": {
             "physical_control": {
                 "name": "物理操作",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,108 @@
+"""Tests for the dLight sensor platform (brightness and color temperature)."""
+from dlightclient import DLightConnectionError
+
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.dlight.const import DOMAIN
+from .conftest import setup_integration
+
+
+async def test_brightness_sensor_initial_value(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Brightness sensor reports the coordinator's current brightness value."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_brightness"
+    )
+    assert entity_id is not None
+
+    entry = er.async_get(hass).async_get(entity_id)
+    assert entry.entity_category == er.EntityCategory.DIAGNOSTIC
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "50"
+    assert state.attributes["unit_of_measurement"] == "%"
+
+
+async def test_color_temp_sensor_initial_value(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Color temperature sensor reports the coordinator's current color temp value."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_color_temp"
+    )
+    assert entity_id is not None
+
+    entry = er.async_get(hass).async_get(entity_id)
+    assert entry.entity_category == er.EntityCategory.DIAGNOSTIC
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "4000"
+    assert state.attributes["unit_of_measurement"] == "K"
+
+
+async def test_sensors_update_on_coordinator_refresh(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Sensor values update when the coordinator polls new state."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    brightness_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_brightness"
+    )
+    color_temp_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_color_temp"
+    )
+
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 75,
+        "color": {"temperature": 3000},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(brightness_id).state == "75"
+    assert hass.states.get(color_temp_id).state == "3000"
+
+
+async def test_sensors_unavailable_on_coordinator_failure(
+    hass, mock_dlight_device, mock_config_entry
+):
+    """Both sensors go unavailable when the coordinator cannot reach the lamp."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    brightness_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_brightness"
+    )
+    color_temp_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "dlight_test_device_id_color_temp"
+    )
+
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("gone")
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(brightness_id).state == "unavailable"
+    assert hass.states.get(color_temp_id).state == "unavailable"
+
+    # Recovery: sensors come back online.
+    mock_dlight_device.get_state.side_effect = None
+    mock_dlight_device.get_state.return_value = {
+        "on": True,
+        "brightness": 60,
+        "color": {"temperature": 4500},
+    }
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(brightness_id).state == "60"
+    assert hass.states.get(color_temp_id).state == "4500"


### PR DESCRIPTION
Closes #64

## Summary
- Adds `sensor.py` platform with two `EntityCategory.DIAGNOSTIC` sensors per lamp: **Brightness** (`%`, unique id `dlight_{id}_brightness`) and **Color Temperature** (`K`, unique id `dlight_{id}_color_temp`).
- Both are `CoordinatorEntity` backed — no extra polling. They go unavailable when `coordinator.last_update_success` is `False`.
- `Platform.SENSOR` added to `PLATFORMS` in `const.py`.
- Localization keys (`brightness`, `color_temp`) added to `strings.json` and all five locale files (`en`, `de`, `fr`, `ga`, `ja`).

## Testing
- 4 new tests in `tests/test_sensor.py`: initial values, update on coordinator refresh, unavailability on failure, and recovery.
- Full test suite: 95 passed, coverage 92% (gate: 80%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)