### PR TITLE
fix(light): clamp color_temp_kelvin to KELVIN_MIN/MAX before sending to device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Clamp `color_temp_kelvin` to `[KELVIN_MIN, KELVIN_MAX]` in `async_turn_on` before issuing device commands; out-of-range values (e.g. 6500 K daylight preset) are silently bounded to the hardware range instead of triggering undefined device behaviour (closes #77).
+
 ## [2.4.0] - 2026-06-14
 
 ### Added

--- a/custom_components/dlight/light.py
+++ b/custom_components/dlight/light.py
@@ -256,6 +256,8 @@ class DLightEntity(CoordinatorEntity[DLightCoordinator], LightEntity):
         """
         brightness: int | None = kwargs.get(ATTR_BRIGHTNESS)
         kelvin: int | None = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
+        if kelvin is not None:
+            kelvin = max(KELVIN_MIN, min(KELVIN_MAX, kelvin))
         transition: float | None = kwargs.get(ATTR_TRANSITION)
 
         _LOGGER.debug(

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -717,6 +717,78 @@ async def test_turn_on_only_kelvin_does_not_use_apply_scene(
 
 
 # ---------------------------------------------------------------------------
+# Kelvin clamping tests (issue #77)
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_on_kelvin_below_min_is_clamped(hass, mock_dlight_device, mock_config_entry):
+    """color_temp_kelvin below KELVIN_MIN is clamped to KELVIN_MIN before the device command."""
+    from custom_components.dlight.const import KELVIN_MIN
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "color_temp_kelvin": 1000},
+        blocking=True,
+    )
+
+    mock_dlight_device.set_color_temperature.assert_called_once_with(KELVIN_MIN)
+    state = hass.states.get("light.test_light")
+    assert state.attributes.get("color_temp_kelvin") == KELVIN_MIN
+
+
+async def test_turn_on_kelvin_above_max_is_clamped(hass, mock_dlight_device, mock_config_entry):
+    """color_temp_kelvin above KELVIN_MAX is clamped to KELVIN_MAX before the device command."""
+    from custom_components.dlight.const import KELVIN_MAX
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "color_temp_kelvin": 9000},
+        blocking=True,
+    )
+
+    mock_dlight_device.set_color_temperature.assert_called_once_with(KELVIN_MAX)
+    state = hass.states.get("light.test_light")
+    assert state.attributes.get("color_temp_kelvin") == KELVIN_MAX
+
+
+async def test_fade_kelvin_target_clamped_at_start(hass, mock_dlight_device, mock_config_entry):
+    """Out-of-range Kelvin is clamped before the fade plan is built; all steps stay in range."""
+    from custom_components.dlight.const import KELVIN_MAX
+    mock_config_entry.add_to_hass(hass)
+    with patch("custom_components.dlight.AsyncDLightClient", autospec=True):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": "light.test_light", "color_temp_kelvin": 8000, "transition": 1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    kelvin_calls = [c.args[0] for c in mock_dlight_device.set_color_temperature.call_args_list]
+    assert kelvin_calls, "Fade sent no set_color_temperature calls"
+    assert all(k <= KELVIN_MAX for k in kelvin_calls), (
+        f"Fade exceeded KELVIN_MAX: {kelvin_calls}"
+    )
+    assert kelvin_calls[-1] == KELVIN_MAX
+
+    state = hass.states.get("light.test_light")
+    assert state.attributes.get("color_temp_kelvin") == KELVIN_MAX
+
+
+# ---------------------------------------------------------------------------
 # Physical button press / external control event tests (issue #18)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #77

## Changes
- Added a single `max(KELVIN_MIN, min(KELVIN_MAX, kelvin))` clamp in `async_turn_on` immediately after reading `color_temp_kelvin` from kwargs. This covers both the instant path (`apply_scene`/`set_color_temperature`) and the fade path (clamped value is passed into `_async_start_turn_on_fade` as the target, so all interpolated steps stay in range).

## Testing
- `test_turn_on_kelvin_below_min_is_clamped`: 1000 K input → `set_color_temperature(2600)` called, entity reports `KELVIN_MIN`
- `test_turn_on_kelvin_above_max_is_clamped`: 9000 K input → `set_color_temperature(6000)` called, entity reports `KELVIN_MAX`
- `test_fade_kelvin_target_clamped_at_start`: 8000 K target with transition → all fade steps ≤ `KELVIN_MAX`, final step lands on `KELVIN_MAX`
- All 102 existing tests continue to pass

## Checklist
- [x] `async_turn_on` clamps `color_temp_kelvin` to `[KELVIN_MIN, KELVIN_MAX]`
- [x] `_fade_plan` / `_async_run_fade` clamp the temperature target at the start of the fade (via the single upfront clamp)
- [x] Tests for below-min, above-max, and fade-with-out-of-range Kelvin
- [x] No change to entity attribute reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)