### PR TITLE
fix(update): keep UpdateEntity available with cached firmware version when lamp is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Override `available` on `DLightUpdateEntity` to return `True` whenever `coordinator.info` contains `swVersion`; the firmware version is static metadata fetched once at setup and should remain visible even while the lamp is unreachable (closes #76).
+
 ## [2.4.0] - 2026-06-14
 
 ### Added

--- a/custom_components/dlight/update.py
+++ b/custom_components/dlight/update.py
@@ -4,8 +4,9 @@ The coordinator fetches swVersion once during setup and caches it in
 coordinator.info. The entity surfaces that as `installed_version`; no OTA
 source is currently known so `latest_version` is always None.
 
-The entity inherits CoordinatorEntity so it goes unavailable when the lamp
-drops off the network (coordinator.last_update_success is False).
+The entity overrides `available` to stay True whenever swVersion is cached,
+even when the lamp is temporarily unreachable. Firmware version is static
+metadata — hiding a known fact due to transient connectivity loss is unhelpful.
 """
 from __future__ import annotations
 

--- a/custom_components/dlight/update.py
+++ b/custom_components/dlight/update.py
@@ -55,6 +55,16 @@ class DLightUpdateEntity(CoordinatorEntity[DLightCoordinator], UpdateEntity):
         )
 
     @property
+    def available(self) -> bool:
+        """Return True when a cached firmware version exists.
+
+        coordinator.info is fetched once at setup and never changes, so
+        swVersion remains known even when the lamp is unreachable. Hiding a
+        known static fact because of a transient connectivity loss is unhelpful.
+        """
+        return bool(self.coordinator.info.get("swVersion"))
+
+    @property
     def installed_version(self) -> str | None:
         """Return the firmware version fetched during coordinator setup."""
         return self.coordinator.info.get("swVersion")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -39,10 +39,10 @@ async def test_firmware_entity_latest_version_is_none(
     assert state.attributes.get("latest_version") is None
 
 
-async def test_firmware_entity_unavailable_on_coordinator_failure(
+async def test_firmware_entity_stays_available_on_coordinator_failure(
     hass, mock_dlight_device, mock_config_entry
 ):
-    """Firmware entity goes unavailable when the coordinator loses the lamp."""
+    """Firmware entity stays available and shows cached version when lamp is offline."""
     await setup_integration(hass, mock_config_entry)
     coordinator = mock_config_entry.runtime_data
 
@@ -56,12 +56,7 @@ async def test_firmware_entity_unavailable_on_coordinator_failure(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == "unavailable"
-
-    # Recovery: entity becomes available again.
-    mock_dlight_device.get_state.side_effect = None
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
-
+    # Entity must remain available — firmware version is static cached metadata.
     assert hass.states.get(entity_id).state != "unavailable"
     assert hass.states.get(entity_id).attributes.get("installed_version") == "1.0.0"
+    assert hass.states.get(entity_id).attributes.get("latest_version") is None


### PR DESCRIPTION
Closes #76

## Changes
- Added `available` property override in `DLightUpdateEntity` returning `True` when `coordinator.info` contains `swVersion`. Since `coordinator.info` is fetched once at setup and never changes, the cached version is always known — no reason to hide it due to a transient connectivity failure.
- Updated `test_firmware_entity_unavailable_on_coordinator_failure` → `test_firmware_entity_stays_available_on_coordinator_failure` to match the new behavior: asserts the entity remains available and continues reporting the cached version during a simulated coordinator failure.

## Testing
- `test_firmware_entity_stays_available_on_coordinator_failure`: simulates `DLightConnectionError` during a coordinator refresh, asserts entity state is not `"unavailable"` and `installed_version` still returns `"1.0.0"`
- All existing tests pass

## Checklist
- [x] `DLightUpdateEntity.available` returns `True` when `coordinator.info` has `swVersion`, even if `coordinator.last_update_success` is `False`
- [x] `installed_version` continues to return the cached `swVersion` string while the lamp is offline
- [x] Test asserting entity stays available during simulated coordinator failure
- [x] `latest_version` behaviour unchanged (still `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)