### PR TITLE
dx(codecov): add coverage flags for sensor, event, and update platforms

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,6 +22,15 @@ flags:
   binary_sensor:
     paths:
       - custom_components/dlight/binary_sensor.py
+  sensor:
+    paths:
+      - custom_components/dlight/sensor.py
+  event:
+    paths:
+      - custom_components/dlight/event.py
+  update:
+    paths:
+      - custom_components/dlight/update.py
 
 component_management:
   default_rules:
@@ -53,3 +62,15 @@ component_management:
       paths:
         - custom_components/dlight/__init__.py
         - custom_components/dlight/const.py
+    - component_id: sensor
+      name: Sensor
+      paths:
+        - custom_components/dlight/sensor.py
+    - component_id: event
+      name: Event
+      paths:
+        - custom_components/dlight/event.py
+    - component_id: update
+      name: Update
+      paths:
+        - custom_components/dlight/update.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,6 +69,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: binary_sensor
 
+      - name: Upload coverage — sensor flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: sensor
+
+      - name: Upload coverage — event flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: event
+
+      - name: Upload coverage — update flag
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: update
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add Codecov flags and component definitions for `sensor`, `event`, and `update` platforms in `.codecov.yml` and `tests.yaml`; per-component coverage is now tracked and enforced for all six platforms (closes #74).
+
 ### Fixed
 - Clamp `color_temp_kelvin` to `[KELVIN_MIN, KELVIN_MAX]` in `async_turn_on` before issuing device commands; out-of-range values (e.g. 6500 K daylight preset) are silently bounded to the hardware range instead of triggering undefined device behaviour (closes #77).
 


### PR DESCRIPTION
Closes #74

## Changes
- `.codecov.yml`: Added `flags` blocks for `sensor`, `event`, and `update` (pointing to `sensor.py`, `event.py`, `update.py`)
- `.codecov.yml`: Added `individual_components` entries for `sensor`, `event`, and `update` in `component_management`
- `.github/workflows/tests.yaml`: Added three Codecov upload steps for the new flags, consistent with existing flag upload pattern

## Testing
- All 102 tests pass
- Coverage structure verified locally with `pytest --cov=custom_components/dlight --cov-report=term-missing`

## Checklist
- [x] `flags` blocks for `sensor`, `event`, and `update` in `.codecov.yml`
- [x] Matching `individual_components` entries with correct paths
- [x] Three new upload steps in `tests.yaml` for per-flag CI uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)