### PR TITLE
dx(diagnostics): enrich snapshot with coordinator health and rediscovery metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Enrich diagnostics snapshot with a `coordinator_health` dict containing `consecutive_failures` (int), `last_success` (ISO timestamp or null), and `rediscovery_in_flight` (bool); no IP addresses are included in the new fields (closes #75).
+
 ### Fixed
 - Clamp `color_temp_kelvin` to `[KELVIN_MIN, KELVIN_MAX]` in `async_turn_on` before issuing device commands; out-of-range values (e.g. 6500 K daylight preset) are silently bounded to the hardware range instead of triggering undefined device behaviour (closes #77).
 

--- a/custom_components/dlight/diagnostics.py
+++ b/custom_components/dlight/diagnostics.py
@@ -23,6 +23,7 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return a redacted snapshot of the entry and its coordinator."""
     coordinator = entry.runtime_data
+    last_success = coordinator.last_successful_poll
     return {
         "entry": {
             "data": async_redact_data(dict(entry.data), TO_REDACT),
@@ -32,4 +33,9 @@ async def async_get_config_entry_diagnostics(
         "state": coordinator.data,  # last polled on/brightness/color
         "last_update_success": coordinator.last_update_success,
         "update_interval": str(coordinator.update_interval),
+        "coordinator_health": {
+            "consecutive_failures": coordinator.consecutive_failures,
+            "last_success": last_success.isoformat() if last_success else None,
+            "rediscovery_in_flight": coordinator.rediscovery_in_progress,
+        },
     }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -71,7 +71,7 @@ async def test_diagnostics_redacts_identifiers(hass):
 
 
 async def test_diagnostics_coordinator_health_on_failure(hass, mock_dlight_device, mock_config_entry):
-    """coordinator_health reflects consecutive failures and null last_success when never polled."""
+    """coordinator_health reflects consecutive failures; last_success retains the pre-failure timestamp."""
     from dlightclient import DLightConnectionError
     from .conftest import setup_integration
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -62,3 +62,30 @@ async def test_diagnostics_redacts_identifiers(hass):
     assert diagnostics["device_info"]["macAddress"] == "**REDACTED**"
     assert diagnostics["last_update_success"] is True
     assert diagnostics["update_interval"] == "0:00:30"
+
+    # Coordinator health fields are present and sane after a successful setup
+    health = diagnostics["coordinator_health"]
+    assert health["consecutive_failures"] == 0
+    assert health["last_success"] is not None  # set by the initial poll
+    assert health["rediscovery_in_flight"] is False
+
+
+async def test_diagnostics_coordinator_health_on_failure(hass, mock_dlight_device, mock_config_entry):
+    """coordinator_health reflects consecutive failures and null last_success when never polled."""
+    from dlightclient import DLightConnectionError
+    from .conftest import setup_integration
+
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+
+    # Simulate two consecutive poll failures
+    mock_dlight_device.get_state.side_effect = DLightConnectionError("offline")
+    await coordinator.async_refresh()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+    health = diagnostics["coordinator_health"]
+    assert health["consecutive_failures"] == 2
+    assert health["last_success"] is not None  # timestamp from initial successful poll
+    assert health["rediscovery_in_flight"] is False


### PR DESCRIPTION
Closes #75

## Changes
- `diagnostics.py`: Added `coordinator_health` key to the snapshot dict with three fields sourced directly from existing `DLightCoordinator` properties:
  - `consecutive_failures` → `coordinator.consecutive_failures` (int)
  - `last_success` → `coordinator.last_successful_poll.isoformat()` or `None`
  - `rediscovery_in_flight` → `coordinator.rediscovery_in_progress` (bool)

## Testing
- Extended `test_diagnostics_redacts_identifiers`: asserts `coordinator_health` keys are present with correct values after a healthy setup (0 failures, non-null last_success, no rediscovery in flight)
- New `test_diagnostics_coordinator_health_on_failure`: simulates two consecutive `DLightConnectionError` poll failures and asserts `consecutive_failures == 2`, `last_success` retains the pre-failure timestamp, `rediscovery_in_flight` is False

## Checklist
- [x] `coordinator_health` dict with `consecutive_failures`, `last_success`, `rediscovery_in_flight`
- [x] No IP addresses in new fields
- [x] Tests assert new keys and correct values
- [x] Snapshot still passes `async_redact_data` expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)