### PR TITLE
feat(services): add dlight.flash service for automation-triggered lamp identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `dlight.flash` service to `__init__.py`; accepts a `device_id` and calls `device.flash()` under `coordinator.command_lock` — enables automation-triggered lamp identification without targeting the button entity (closes #78).
+
 ### Changed
 - Add Codecov flags and component definitions for `sensor`, `event`, and `update` platforms in `.codecov.yml` and `tests.yaml`; per-component coverage is now tracked and enforced for all six platforms (closes #74).
 

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -11,16 +11,19 @@ from dlightclient import AsyncDLightClient, DLightDevice
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_DEVICE_ID, PLATFORMS
+from .const import CONF_DEVICE_ID, DOMAIN, PLATFORMS
 from .coordinator import DLightCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 # The typed alias every signature uses: runtime_data carries the coordinator.
 type DLightConfigEntry = ConfigEntry[DLightCoordinator]
+
+SERVICE_FLASH = "flash"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bool:
@@ -62,6 +65,49 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
             coordinator._handle_device_state_change
         )
     )
+
+    # Register the dlight.flash service once; idempotent across multi-lamp setups.
+    if not hass.services.has_service(DOMAIN, SERVICE_FLASH):
+        async def _handle_flash(call: ServiceCall) -> None:
+            target_device_id: str | None = call.data.get("device_id")
+            if not target_device_id:
+                return
+            dev_reg = dr.async_get(hass)
+            device_entry = dev_reg.async_get(target_device_id)
+            if not device_entry:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="flash_unknown_device",
+                    translation_placeholders={"device_id": target_device_id},
+                )
+            for entry_id in device_entry.config_entries:
+                cfg = hass.config_entries.async_get_entry(entry_id)
+                if cfg and cfg.domain == DOMAIN and cfg.runtime_data is not None:
+                    coord = cfg.runtime_data
+                    coord.identify_in_progress = True
+                    try:
+                        async with coord.command_lock:
+                            await coord.device.flash()
+                    finally:
+                        coord.identify_in_progress = False
+                    return
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="flash_unknown_device",
+                translation_placeholders={"device_id": target_device_id},
+            )
+
+        hass.services.async_register(DOMAIN, SERVICE_FLASH, _handle_flash)
+
+    def _maybe_remove_service() -> None:
+        remaining = [
+            e for e in hass.config_entries.async_entries(DOMAIN)
+            if e.entry_id != entry.entry_id
+        ]
+        if not remaining and hass.services.has_service(DOMAIN, SERVICE_FLASH):
+            hass.services.async_remove(DOMAIN, SERVICE_FLASH)
+
+    entry.async_on_unload(_maybe_remove_service)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -12,7 +12,7 @@ from dlightclient import AsyncDLightClient, DLightDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryError, ServiceValidationError
+from homeassistant.exceptions import ConfigEntryError, HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_DEVICE_ID, DOMAIN, PLATFORMS
@@ -71,7 +71,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
         async def _handle_flash(call: ServiceCall) -> None:
             target_device_id: str | None = call.data.get("device_id")
             if not target_device_id:
-                return
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="flash_unknown_device",
+                    translation_placeholders={"device_id": ""},
+                )
             dev_reg = dr.async_get(hass)
             device_entry = dev_reg.async_get(target_device_id)
             if not device_entry:
@@ -83,13 +87,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
             for entry_id in device_entry.config_entries:
                 cfg = hass.config_entries.async_get_entry(entry_id)
                 if cfg and cfg.domain == DOMAIN and cfg.runtime_data is not None:
-                    coord = cfg.runtime_data
+                    coord: DLightCoordinator = cfg.runtime_data
+                    device = coord.device
                     coord.identify_in_progress = True
                     try:
                         async with coord.command_lock:
-                            await coord.device.flash()
+                            success = await device.flash()
+                    except Exception as err:
+                        _LOGGER.exception("Flash service failed for dLight %s", device.id)
+                        raise HomeAssistantError(
+                            translation_domain=DOMAIN,
+                            translation_key="identify_failed",
+                            translation_placeholders={
+                                "device_name": cfg.title or f"dLight {device.id}",
+                                "error": str(err),
+                            },
+                        ) from err
                     finally:
                         coord.identify_in_progress = False
+                    if not success:
+                        raise HomeAssistantError(
+                            translation_domain=DOMAIN,
+                            translation_key="identify_failed",
+                            translation_placeholders={
+                                "device_name": cfg.title or f"dLight {device.id}",
+                                "error": "flash sequence did not complete",
+                            },
+                        )
                     return
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -100,10 +124,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
         hass.services.async_register(DOMAIN, SERVICE_FLASH, _handle_flash)
 
     def _maybe_remove_service() -> None:
-        remaining = [
-            e for e in hass.config_entries.async_entries(DOMAIN)
-            if e.entry_id != entry.entry_id
-        ]
+        remaining = []
+        for e in hass.config_entries.async_entries(DOMAIN):
+            if e.entry_id == entry.entry_id:
+                continue
+            try:
+                # Only count entries that completed setup successfully.
+                if e.runtime_data is not None:
+                    remaining.append(e)
+            except Exception:  # noqa: BLE001
+                pass
         if not remaining and hass.services.has_service(DOMAIN, SERVICE_FLASH):
             hass.services.async_remove(DOMAIN, SERVICE_FLASH)
 

--- a/custom_components/dlight/__init__.py
+++ b/custom_components/dlight/__init__.py
@@ -86,8 +86,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: DLightConfigEntry) -> bo
                 )
             for entry_id in device_entry.config_entries:
                 cfg = hass.config_entries.async_get_entry(entry_id)
-                if cfg and cfg.domain == DOMAIN and cfg.runtime_data is not None:
-                    coord: DLightCoordinator = cfg.runtime_data
+                if not cfg or cfg.domain != DOMAIN:
+                    continue
+                try:
+                    coord_or_none = cfg.runtime_data
+                except (AttributeError, RuntimeError):
+                    continue
+                if coord_or_none is not None:
+                    coord: DLightCoordinator = coord_or_none
                     device = coord.device
                     coord.identify_in_progress = True
                     try:

--- a/custom_components/dlight/services.yaml
+++ b/custom_components/dlight/services.yaml
@@ -1,0 +1,11 @@
+flash:
+  name: Flash
+  description: Blinks the lamp briefly to identify it physically in a room.
+  fields:
+    device_id:
+      name: Device
+      description: The dLight lamp to flash.
+      required: true
+      selector:
+        device:
+          integration: dlight

--- a/custom_components/dlight/strings.json
+++ b/custom_components/dlight/strings.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "Flash",
-            "description": "Blinks the lamp briefly to identify it physically in a room."
+            "description": "Blinks the lamp briefly to identify it physically in a room.",
+            "fields": {
+                "device_id": {
+                    "name": "Device",
+                    "description": "The dLight lamp to flash."
+                }
+            }
         }
     }
 }

--- a/custom_components/dlight/strings.json
+++ b/custom_components/dlight/strings.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "Failed to identify {device_name}. Device reported: {error}"
+        },
+        "flash_unknown_device": {
+            "message": "Unknown device ID: {device_id}. Make sure the target is a configured dLight lamp."
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "Flash",
+            "description": "Blinks the lamp briefly to identify it physically in a room."
         }
     }
 }

--- a/custom_components/dlight/translations/de.json
+++ b/custom_components/dlight/translations/de.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "Fehler beim Identifizieren von {device_name}. Das Gerät meldete: {error}"
+        },
+        "flash_unknown_device": {
+            "message": "Unbekannte Geräte-ID: {device_id}. Stellen Sie sicher, dass das Ziel eine konfigurierte dLight-Lampe ist."
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "Blinken",
+            "description": "Lässt die Lampe kurz aufleuchten, um sie physisch im Raum zu identifizieren."
         }
     }
 }

--- a/custom_components/dlight/translations/de.json
+++ b/custom_components/dlight/translations/de.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "Blinken",
-            "description": "Lässt die Lampe kurz aufleuchten, um sie physisch im Raum zu identifizieren."
+            "description": "Lässt die Lampe kurz aufleuchten, um sie physisch im Raum zu identifizieren.",
+            "fields": {
+                "device_id": {
+                    "name": "Gerät",
+                    "description": "Die dLight-Lampe, die blinken soll."
+                }
+            }
         }
     }
 }

--- a/custom_components/dlight/translations/en.json
+++ b/custom_components/dlight/translations/en.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "Flash",
-            "description": "Blinks the lamp briefly to identify it physically in a room."
+            "description": "Blinks the lamp briefly to identify it physically in a room.",
+            "fields": {
+                "device_id": {
+                    "name": "Device",
+                    "description": "The dLight lamp to flash."
+                }
+            }
         }
     }
 }

--- a/custom_components/dlight/translations/en.json
+++ b/custom_components/dlight/translations/en.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "Failed to identify {device_name}. Device reported: {error}"
+        },
+        "flash_unknown_device": {
+            "message": "Unknown device ID: {device_id}. Make sure the target is a configured dLight lamp."
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "Flash",
+            "description": "Blinks the lamp briefly to identify it physically in a room."
         }
     }
 }

--- a/custom_components/dlight/translations/fr.json
+++ b/custom_components/dlight/translations/fr.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "Clignoter",
-            "description": "Fait clignoter brièvement la lampe pour l'identifier physiquement dans une pièce."
+            "description": "Fait clignoter brièvement la lampe pour l'identifier physiquement dans une pièce.",
+            "fields": {
+                "device_id": {
+                    "name": "Appareil",
+                    "description": "La lampe dLight à faire clignoter."
+                }
+            }
         }
     }
 }

--- a/custom_components/dlight/translations/fr.json
+++ b/custom_components/dlight/translations/fr.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "Échec de l'identification de {device_name}. L'appareil a signalé : {error}"
+        },
+        "flash_unknown_device": {
+            "message": "Identifiant d'appareil inconnu : {device_id}. Assurez-vous que la cible est une lampe dLight configurée."
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "Clignoter",
+            "description": "Fait clignoter brièvement la lampe pour l'identifier physiquement dans une pièce."
         }
     }
 }

--- a/custom_components/dlight/translations/ga.json
+++ b/custom_components/dlight/translations/ga.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "Splancadh",
-            "description": "Caochnaíonn an lampa go gairid chun é a aithint go fisiciúil sa seomra."
+            "description": "Caochnaíonn an lampa go gairid chun é a aithint go fisiciúil sa seomra.",
+            "fields": {
+                "device_id": {
+                    "name": "Gléas",
+                    "description": "An lampa dLight atá le caochadh."
+                }
+            }
         }
     }
 }

--- a/custom_components/dlight/translations/ga.json
+++ b/custom_components/dlight/translations/ga.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "Theip ar {device_name} a aithint. Thuairiscigh an gléas: {error}"
+        },
+        "flash_unknown_device": {
+            "message": "Aitheantas gléis anaithnid: {device_id}. Déan cinnte gurb é an sprioc lampa dLight cumraithe."
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "Splancadh",
+            "description": "Caochnaíonn an lampa go gairid chun é a aithint go fisiciúil sa seomra."
         }
     }
 }

--- a/custom_components/dlight/translations/ja.json
+++ b/custom_components/dlight/translations/ja.json
@@ -94,6 +94,15 @@
         },
         "identify_failed": {
             "message": "{device_name} の識別に失敗しました。デバイスの報告: {error}"
+        },
+        "flash_unknown_device": {
+            "message": "不明なデバイスID: {device_id}。対象が設定済みのdLightランプであることを確認してください。"
+        }
+    },
+    "services": {
+        "flash": {
+            "name": "フラッシュ",
+            "description": "ランプを短く点滅させて、部屋の中で物理的に識別します。"
         }
     }
 }

--- a/custom_components/dlight/translations/ja.json
+++ b/custom_components/dlight/translations/ja.json
@@ -102,7 +102,13 @@
     "services": {
         "flash": {
             "name": "フラッシュ",
-            "description": "ランプを短く点滅させて、部屋の中で物理的に識別します。"
+            "description": "ランプを短く点滅させて、部屋の中で物理的に識別します。",
+            "fields": {
+                "device_id": {
+                    "name": "デバイス",
+                    "description": "点滅させるdLightランプ。"
+                }
+            }
         }
     }
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -179,6 +179,72 @@ async def test_flash_service_raises_on_device_flash_failure(hass, mock_dlight_de
         )
 
 
+async def test_flash_service_raises_on_empty_device_id(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash raises ServiceValidationError when called with an empty device_id."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_FLASH,
+            {"device_id": ""},
+            blocking=True,
+        )
+
+
+async def test_flash_service_raises_on_device_flash_exception(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash raises HomeAssistantError when flash() throws an exception."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    mock_dlight_device.flash.side_effect = Exception("device exploded")
+    await setup_integration(hass, mock_config_entry)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device is not None
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_FLASH,
+            {"device_id": device.id},
+            blocking=True,
+        )
+
+
+async def test_flash_service_raises_when_no_coordinator_for_device(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash raises ServiceValidationError when the device has no loaded coordinator."""
+    from homeassistant.exceptions import ServiceValidationError
+    from homeassistant.helpers import device_registry as dr_module
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Add a second device entry linked only to a "ghost" entry with no coordinator.
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"ip_address": "10.0.0.1", "device_id": "ghost_id"},
+        title="Ghost Lamp",
+        entry_id="ghost_entry_id",
+    )
+    other_entry.add_to_hass(hass)
+    dev_reg = dr_module.async_get(hass)
+    ghost_device = dev_reg.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={(DOMAIN, "ghost_id")},
+        name="Ghost Lamp",
+    )
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_FLASH,
+            {"device_id": ghost_device.id},
+            blocking=True,
+        )
+
+
 async def test_flash_service_removed_on_last_entry_unload(hass, mock_dlight_device, mock_config_entry):
     """dlight.flash service is removed when the last entry is unloaded."""
     await setup_integration(hass, mock_config_entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,9 +6,11 @@ from dlightclient import DLightConnectionError
 from homeassistant.config_entries import ConfigEntryNotReady
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.dlight.const import CONF_DEVICE_ID, DOMAIN
+from custom_components.dlight import SERVICE_FLASH
 from .conftest import setup_integration
 
 
@@ -110,3 +112,59 @@ async def test_setup_entry_raises_config_entry_error_on_missing_device_id(hass, 
 
     assert result is False
     assert bad_entry.state.value == "setup_error"
+
+
+# ---------------------------------------------------------------------------
+# dlight.flash service tests (issue #78)
+# ---------------------------------------------------------------------------
+
+
+async def test_flash_service_registered_on_setup(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash service is registered after a successful entry setup."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.services.has_service(DOMAIN, SERVICE_FLASH)
+
+
+async def test_flash_service_calls_device_flash(hass, mock_dlight_device, mock_config_entry):
+    """Calling dlight.flash finds the coordinator and calls device.flash()."""
+    mock_dlight_device.flash.return_value = True
+    await setup_integration(hass, mock_config_entry)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_FLASH,
+        {"device_id": device.id},
+        blocking=True,
+    )
+
+    mock_dlight_device.flash.assert_called_once()
+
+
+async def test_flash_service_unknown_device_raises(hass, mock_dlight_device, mock_config_entry):
+    """Calling dlight.flash with an unknown device_id raises ServiceValidationError."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_FLASH,
+            {"device_id": "nonexistent-device-id"},
+            blocking=True,
+        )
+
+
+async def test_flash_service_removed_on_last_entry_unload(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash service is removed when the last entry is unloaded."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.services.has_service(DOMAIN, SERVICE_FLASH)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.services.has_service(DOMAIN, SERVICE_FLASH)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -159,6 +159,26 @@ async def test_flash_service_unknown_device_raises(hass, mock_dlight_device, moc
         )
 
 
+async def test_flash_service_raises_on_device_flash_failure(hass, mock_dlight_device, mock_config_entry):
+    """dlight.flash raises HomeAssistantError when flash() returns False."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    mock_dlight_device.flash.return_value = False
+    await setup_integration(hass, mock_config_entry)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "test_device_id")})
+    assert device is not None
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_FLASH,
+            {"device_id": device.id},
+            blocking=True,
+        )
+
+
 async def test_flash_service_removed_on_last_entry_unload(hass, mock_dlight_device, mock_config_entry):
     """dlight.flash service is removed when the last entry is unloaded."""
     await setup_integration(hass, mock_config_entry)


### PR DESCRIPTION
Closes #78

## Summary
- Registers a `dlight.flash` service in `__init__.py` that accepts a `device_id` field and calls `device.flash()` under `coordinator.command_lock`
- Adds `services.yaml` with a `device` selector scoped to the `dlight` integration
- Updates `strings.json` and all 5 locale files (`en`, `de`, `fr`, `ja`, `ga`) with `services.flash` translations and `flash_unknown_device` exception key
- Service is registered idempotently (once per domain) and removed when the last entry unloads

## Why
Automations could previously only trigger lamp identification through the Identify button entity, which isn't selectable in standard service call actions. This surfaces flashing as a first-class `dlight.flash` service callable from automations, scripts, and the developer tools service panel.

## Test plan
- [x] `test_flash_service_registered_on_setup` — service present after setup
- [x] `test_flash_service_calls_device_flash` — device.flash() called with correct device
- [x] `test_flash_service_unknown_device_raises` — ServiceValidationError for unknown device_id
- [x] `test_flash_service_removed_on_last_entry_unload` — service removed after unload
- [x] All 106 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)